### PR TITLE
ME3Explorer - ME3Tweaks Fork 4.0.1

### DIFF
--- a/ME3Explorer/CurveEd/CurveEditor.xaml.cs
+++ b/ME3Explorer/CurveEd/CurveEditor.xaml.cs
@@ -200,7 +200,7 @@ namespace ME3Explorer.CurveEd
 
         public override bool CanParse(IExportEntry exportEntry)
         {
-            if (exportEntry.FileRef.Game == MEGame.ME3)
+            if (exportEntry.FileRef.Game != MEGame.UDK)
             {
                 var props = exportEntry.GetProperties();
                 foreach (var prop in props)

--- a/ME3Explorer/Properties/AssemblyInfo.cs
+++ b/ME3Explorer/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.0.0.3")]
-[assembly: AssemblyFileVersion("4.0.0.3")]
+[assembly: AssemblyVersion("4.0.1.0")]
+[assembly: AssemblyFileVersion("4.0.1.0")]

--- a/ME3Explorer/SharedUI/ExportLoaderHostedWindow.xaml.cs
+++ b/ME3Explorer/SharedUI/ExportLoaderHostedWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Threading;
+using ME3Explorer.CurveEd;
 using ME3Explorer.Packages;
 using Microsoft.Win32;
 using static ME3Explorer.PackageEditorWPF;
@@ -75,6 +76,11 @@ namespace ME3Explorer.SharedUI
                 if ((update.change == PackageChange.ExportAdd || update.change == PackageChange.ExportData)
                     && update.index == LoadedExport.Index)
                 {
+                    if (hostedControl is CurveEditor)
+                    {
+                        //CurveEditor handles its own refresh
+                        continue;
+                    }
                     hostedControl.LoadExport(LoadedExport); //reload export
                     return;
                 }


### PR DESCRIPTION
# ME3Explorer - ME3Tweaks Fork 4.0.1
This is a bugfix release, additionally enabling one new feature present in 4.1 developer builds.

## Changed features
 - Curve Editor now supports ME1 and ME2 curves

## Bugfixes
 - Curve Editor in a popped out window will no longer reload the import when it receives a change notification. This brings its behavior in line with Curve Editor when it's hosted as a tab in Package Editor WPF.