### PR TITLE
ME3Explorer - ME3Tweaks Fork 4.1.1

### DIFF
--- a/ME3Explorer/MEDirectories/ME2Directory.cs
+++ b/ME3Explorer/MEDirectories/ME2Directory.cs
@@ -123,7 +123,7 @@ namespace ME3Explorer
             "DLC_UNC_Pack01", //132
             "DLC_CER_02",
             "DLC_MCR_01", //136
-            "DLC_MCR_03 ",
+            "DLC_MCR_03",
             "DLC_EXP_Part01", //300
             "DLC_DHME1", //375
             "DLC_CON_Pack02", //380

--- a/ME3Explorer/MEDirectories/ME2Directory.cs
+++ b/ME3Explorer/MEDirectories/ME2Directory.cs
@@ -88,7 +88,7 @@ namespace ME3Explorer
             ["DLC_HEN_MT"] = "Kasumi - Stolen Memory",
             ["DLC_HEN_VT"] = "Zaeed - The Price of Revenge",
             ["DLC_MCR_01"] = "Firepower pack",
-            ["DLC_MCR_03 "] = "Equalizer pack",
+            ["DLC_MCR_03"] = "Equalizer pack",
             ["DLC_PRE_Cerberus"] = "Cerberus Weapon and Armor",
             ["DLC_PRE_Collectors"] = "Collectors' Weapon and Armor",
             ["DLC_PRE_DA"] = "Blood Dragon Armor",

--- a/ME3Explorer/PackageEditor/TextureViewer/TextureViewerExportLoader.xaml.cs
+++ b/ME3Explorer/PackageEditor/TextureViewer/TextureViewerExportLoader.xaml.cs
@@ -516,7 +516,7 @@ namespace ME3Explorer
                     //Leave here for future. WE might need this after dealing with double compression
                     //if (mipmap.storageType == StorageTypes.pccUnc && mipmap.width > 32) //ME3 Uncomp -> ZLib
                     //    mipmap.storageType = StorageTypes.pccZlib;
-                    if (mipmap.storageType == StorageTypes.pccUnc && mipmap.width > 32 && textureCache != null) //Moving texture to store externally.
+                    if (mipmap.storageType == StorageTypes.pccUnc && m < image.mipMaps.Count() - 6 && textureCache != null) //Moving texture to store externally.
                         mipmap.storageType = StorageTypes.extZlib;
                 }
                 else if (texture.Export.Game == MEGame.ME2)
@@ -530,7 +530,7 @@ namespace ME3Explorer
                     //Leave here for future. We might neable this after dealing with double compression
                     //if (mipmap.storageType == StorageTypes.pccUnc && mipmap.width > 32) //ME2 Uncomp -> LZO
                     //    mipmap.storageType = StorageTypes.pccLZO;
-                    if (mipmap.storageType == StorageTypes.pccUnc && mipmap.width > 32 && textureCache != null) //Moving texture to store externally.
+                    if (mipmap.storageType == StorageTypes.pccUnc && m < image.mipMaps.Count() - 6 && textureCache != null) //Moving texture to store externally. make sure bottom 6 are pcc stored
                         mipmap.storageType = StorageTypes.extLZO;
                 }
 
@@ -805,54 +805,6 @@ namespace ME3Explorer
                             }
                             continue;
                         }
-                        //{
-                        //    triggerCacheArc = true;
-
-                        //    if (!newTfcFile && oldSpace)
-                        //    {
-                        //        try
-                        //        {
-                        //            using (FileStream fs = new FileStream(archiveFile, FileMode.Open, FileAccess.Write))
-                        //            {
-                        //                Texture.MipMap oldMipmap = texture.getMipmap(mipmap.width, mipmap.height);
-                        //                fs.JumpTo(oldMipmap.dataOffset);
-                        //                mipmap.dataOffset = oldMipmap.dataOffset;
-                        //                fs.WriteFromBuffer(mipmap.newData);
-                        //            }
-                        //        }
-                        //        catch
-                        //        {
-                        //            throw new Exception("Problem with access to TFC file: " + archiveFile);
-                        //        }
-                        //    }
-                        //    else
-                        //    {
-                        //        try
-                        //        {
-                        //            using (FileStream fs = new FileStream(archiveFile, FileMode.Open, FileAccess.Write))
-                        //            {
-                        //                fs.SeekEnd();
-                        //                mipmap.dataOffset = (uint)fs.Position;
-                        //                fs.WriteFromBuffer(mipmap.newData);
-                        //            }
-                        //        }
-                        //        catch
-                        //        {
-                        //            throw new Exception("Problem with access to TFC file: " + archiveFile);
-                        //        }
-                        //    }
-                        //}
-                        //else
-
-                        //UNSURE WHAT THIS DOES - MIGHT BE IMPORTANT.
-                        //{
-                        //    if ((mipmap.width >= 4 && mod.arcTexture[m].width != mipmap.width) ||
-                        //        (mipmap.height >= 4 && mod.arcTexture[m].height != mipmap.height))
-                        //    {
-                        //        throw new Exception("Dimensions mismatch!");
-                        //    }
-                        //    mipmap.dataOffset = mod.arcTexture[m].dataOffset;
-                        //}
                     }
                 }
                 mipmaps[m] = mipmap;


### PR DESCRIPTION
This is a bugfix build.

## Bugs fixed
 - DLC_MCR_03 would not resolve as an official DLC in the ME2Directory system. Where this was used, not entirely sure, but it's been fixed. Perhaps in TFC Compactor.
 - Texture replacement through the texture tab will work properly now as it will ensure the bottom 6 mips are always packaged stored. Before, there was a chance (depending on texture) that some would be externally stored, and the game would not load these mips.


See full changelog for 4.1 at #154 