### PR TITLE
Optimize name table lookups

### DIFF
--- a/ME3ExplorerCore/Packages/MEPackage.cs
+++ b/ME3ExplorerCore/Packages/MEPackage.cs
@@ -389,7 +389,9 @@ namespace ME3ExplorerCore.Packages
             inStream.JumpTo(NameOffset);
             for (int i = 0; i < NameCount; i++)
             {
-                names.Add(packageReader.ReadUnrealString());
+                var name = packageReader.ReadUnrealString();
+                names.Add(name);
+                nameLookupTable[name] = i;
                 if (Game == MEGame.ME1 && Platform != GamePlatform.PS3)
                     inStream.Skip(8);
                 else if (Game == MEGame.ME2 && Platform != GamePlatform.PS3)

--- a/ME3ExplorerCore/Packages/UDKPackage.cs
+++ b/ME3ExplorerCore/Packages/UDKPackage.cs
@@ -171,7 +171,9 @@ namespace ME3ExplorerCore.Packages
             inStream.JumpTo(NameOffset);
             for (int i = 0; i < NameCount; i++)
             {
-                names.Add(inStream.ReadUnrealString());
+                var name = inStream.ReadUnrealString();
+                names.Add(name);
+                nameLookupTable[name] = i;
                 inStream.Skip(8);
             }
 

--- a/ME3ExplorerCore/Packages/UnrealPackageFile.cs
+++ b/ME3ExplorerCore/Packages/UnrealPackageFile.cs
@@ -91,7 +91,7 @@ namespace ME3ExplorerCore.Packages
             {
                 names.Add(name);
                 namesAdded++;
-                nameLookupTable[name] = (int) namesAdded; //This should be correct...?
+                nameLookupTable[name] = names.Count - 1;
                 NameCount = names.Count;
 
                 updateTools(PackageChange.NameAdd, NameCount - 1);


### PR DESCRIPTION
This closes #200.

This PR changes how names are looked up in MEPackage and UDKPackage. I now add an additional CaseInsensitiveDictionary<int> to each instantiation of a package file, and this dictionary maps strings to their index.

The existing lookup method would enumerate every single name in order to determine if it was present in the list (essentially a .Contains). When found it would return the index. In files that have thousands of names this is not very efficient.

The new lookup method looks for the name in the dictionary, which is ordered by the hash of the string. It's case insensitive and is updated when the name tables changes or is initialized. This has some memory overhead to store a duplicate name table in memory and a slight performance hit on instantiation, but it is not very noticeable doing one package at a time.

However, doing unit tests with thousands of exports, name lookups and reserializations, this old lookup method is _terribly inefficient_. Using dotTrace to profile the TestBinaryConverters() unit test (the longest one by far) _this new implementation cut it down from over 225 seconds minutes to 21 seconds_!.

The old method:
![image](https://user-images.githubusercontent.com/2738836/95419856-a69a3380-08f7-11eb-95d3-ecb875c83bb6.png)

The new method:
![2020-10-07_23h40_01](https://user-images.githubusercontent.com/2738836/95419872-ac901480-08f7-11eb-98f5-1da275c4c4b1.png)

I ran this test a few times to make sure it wasn't disk caching and the results were reproducible. This should hopefully drastically cut down on our time building on azure and improve local responsiveness (though, single package change may not be very noticable unless a big bulk operation is taking place, like transplanting exports between packages).

I'm going to pull my dusty old CS degree out of my hat and throw some big words around I only kind of remember what they mean: Essentially this changes name index lookups from O(n) to O(1), which is a pretty good optimization.

I opened this as a PR as this is a pretty core change to the library and wanted some input. It shouldn't change any of the outward facing API for the package classes so it's all internal. I looked into some other ways like ordered dictionaries but it seems just mapping a name to it's list index works. Since we don't support swapping or inserting names at non-end-of-list locations, this seemed like a good solution, and the unit tests still are OK for reserialization.

Update: Our build time on azure went down from almost 55+ minutes down to less than 15!