### PR TITLE
Assign the ME3 directory to the correct property in CoreLibSettings

### DIFF
--- a/ME3ExplorerCore/MEDirectories/ME3Directory.cs
+++ b/ME3ExplorerCore/MEDirectories/ME3Directory.cs
@@ -61,7 +61,7 @@ namespace ME3ExplorerCore.MEDirectories
                 if (test != null)
                 {
                     gamePath = test;
-                    CoreLibSettings.Instance.ME2Directory = gamePath;
+                    CoreLibSettings.Instance.ME3Directory = gamePath;
                     return;
                 }
 
@@ -70,7 +70,7 @@ namespace ME3ExplorerCore.MEDirectories
                 if (gamePath != null)
                 {
                     gamePath += Path.DirectorySeparatorChar;
-                    CoreLibSettings.Instance.ME2Directory = gamePath;
+                    CoreLibSettings.Instance.ME3Directory = gamePath;
                 }
 #endif
             }


### PR DESCRIPTION
Static constructors for ME1Directory and ME2Directory fetch game paths from registry and assign them to respective properties in CoreLibSettings singleton, but ME3Directory sets the one for ME2. This is probably a bug, as I discovered this when the Package Editor failed to open an ME2 scaleform in JPEXS (see screenshot).

![broken_jpexs](https://user-images.githubusercontent.com/16708023/96181998-8133a800-0f3d-11eb-865a-3bc493efe0fb.jpg)

Opening ME2's `GUI_SF_Conversation.pcc` as in the screenshot above should reproduce the issue (built from Beta latest). 'Game paths' box in the main pane of the toolset also shows an incorrect path, ME3's one in ME2's box (see screenshot below).

![image](https://user-images.githubusercontent.com/16708023/96183170-2c912c80-0f3f-11eb-8ae2-b2feca8db95b.png)

If this is indeed a bug, should I also open an issue covering this for ~~posterity~~ consistency?
