### PR TITLE
FaceFXEd: Add more information to lines list

### DIFF
--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml
@@ -8,9 +8,13 @@
              xmlns:curveEd="clr-namespace:ME3Explorer.CurveEd"
              xmlns:forms="clr-namespace:System.Windows.Forms;assembly=System.Windows.Forms"
              xmlns:binaryConverters="clr-namespace:ME3ExplorerCore.Unreal.BinaryConverters;assembly=ME3ExplorerCore"
+             xmlns:Converters="clr-namespace:ME3Explorer.SharedUI.Converters"
              mc:Ignorable="d" 
              d:DataContext="{Binding RelativeSource={RelativeSource Self}}"
              d:DesignHeight="450" d:DesignWidth="800">
+    <me3explorer:ExportLoaderControl.Resources>
+        <Converters:NullVisibilityConverter x:Key="NullVisibilityConverter"/>
+    </me3explorer:ExportLoaderControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Name="linesColumnDef" Width="310"/>
@@ -29,14 +33,16 @@
                 <RowDefinition/>
                 <RowDefinition Height="155"/>
             </Grid.RowDefinitions>
-            <ListBox x:Name="linesListBox" SelectedItem="{Binding SelectedLine}"
+            <ListBox x:Name="linesListBox" SelectedItem="{Binding SelectedLineEntry}"
                  AllowDrop="True" PreviewMouseLeftButtonDown="linesListBox_PreviewMouseLeftButtonDown" MouseMove="linesListBox_MouseMove"
                  DragEnter="linesListBox_DragEnter" Drop="linesListBox_Drop" HorizontalContentAlignment="Stretch" PreviewMouseRightButtonDown="linesListBox_PreviewMouseRightButtonDown">
                 <ListBox.ItemTemplate>
-                    <DataTemplate DataType="binaryConverters:FaceFXLine">
-                        <TextBlock>
-                                <Run Text="{Binding NameAsString}"/>
-                            <TextBlock.ContextMenu>
+                    <DataTemplate DataType="SelectedLineEntry">
+                        <StackPanel>
+                            <TextBlock Text="{Binding Line.NameAsString}" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding TLKString}" TextWrapping="Wrap" FontSize="10" FontStyle="Italic"  Visibility="{Binding TLKString, Converter={StaticResource NullVisibilityConverter}}"/>
+                            <TextBlock Text="{Binding LengthAsString}" VerticalAlignment="Center" Foreground="Gray"/>
+                            <StackPanel.ContextMenu>
                                 <ContextMenu x:Name="lineContextMenu">
                                     <MenuItem Header="Delete Section of line" Click="DelLineSec_Click"/>
                                     <MenuItem Header="Import Section of line" Click="ImpLineSec_Click"/>
@@ -44,8 +50,8 @@
                                     <MenuItem Header="Offset keys after time" Click="OffsetKeysAfterTime_Click" />
                                     <MenuItem Header="Delete Line" Click="DeleteLine_Click"/>
                                 </ContextMenu>
-                            </TextBlock.ContextMenu>
-                        </TextBlock>
+                            </StackPanel.ContextMenu>
+                        </StackPanel>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
                 <ListBox.Style>
@@ -65,11 +71,11 @@
                     </Style>
                 </ListBox.Style>
             </ListBox>
-            <WindowsFormsHost Grid.Row="1" Name="treeView_WinFormsHost">
+            <WindowsFormsHost Grid.Row="1" Margin="0,5,0,0"  Name="treeView_WinFormsHost">
                 <forms:TreeView x:Name="treeView" MouseDoubleClick="treeView_MouseDoubleClick"/>
             </WindowsFormsHost>
         </Grid>
-        <GridSplitter Grid.Row="0" Grid.RowSpan="2" Width="5" HorizontalAlignment="Stretch" Grid.Column="1"/>
+        <GridSplitter Grid.Row="1" Grid.RowSpan="2" Width="5" HorizontalAlignment="Stretch" Grid.Column="1"/>
         <Label Content="Animations" Grid.Row="0" Grid.Column="2"/>
         <ListBox x:Name="animationListBox" Grid.Column="2" Grid.Row="1" SelectionChanged="animationListBox_SelectionChanged" 
                      AllowDrop="True" PreviewMouseLeftButtonDown="animationListBox_PreviewMouseLeftButtonDown" MouseMove="animationListBox_MouseMove"
@@ -100,7 +106,7 @@
                 <RowDefinition Name="lineTextRowDef" Height="40"/>
             </Grid.RowDefinitions>
             <curveEd:CurveGraph x:Name="graph" DockPanel.Dock="Right" KeyDown="Graph_KeyDown"/>
-            <TextBlock Name="lineText" Grid.Row="1" TextWrapping="Wrap"/>
+            <TextBlock Text="{Binding SelectedLineEntry.TLKString}" Grid.Row="1" TextWrapping="Wrap"/>
         </Grid>
     </Grid>
 </me3explorer:ExportLoaderControl>

--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXEditor.xaml
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXEditor.xaml
@@ -30,6 +30,17 @@
                 <MenuItem Name="Recents_MenuItem" Header="Recent" IsEnabled="false"/>
             </MenuItem>
         </Menu>
+        <StatusBar Height="23" DockPanel.Dock="Bottom">
+            <SharedUI:StatusBarGameIDIndicator GameType="{Binding Pcc.Game}" Margin="0,-4"/>
+            <StatusBarItem>
+                <TextBlock Name="StatusBar_LeftMostText" Text="{Binding CurrentFile}"/>
+            </StatusBarItem>
+            <StatusBarItem HorizontalAlignment="Right">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Name="StatusBar_RightSide_LastSaved" Text="{Binding Pcc.LastSaved, StringFormat='Last saved at {0}'}" Foreground="Gray"/>
+                </StackPanel>
+            </StatusBarItem>
+        </StatusBar>
         <Grid>
             <Grid Visibility="{Binding Pcc, Converter={StaticResource NullVisibilityConverter}, ConverterParameter='Reversed'}">
                 <Grid.ColumnDefinitions>
@@ -65,7 +76,7 @@
                 </StackPanel>
                 <SharedUI:RecentsControl x:Name="RecentsController" Grid.Column="1" Margin="50"/>
             </Grid>
-            <DockPanel Visibility="{Binding Pcc, Converter={StaticResource NullVisibilityConverter}}">
+            <DockPanel Margin="5" Visibility="{Binding Pcc, Converter={StaticResource NullVisibilityConverter}}">
                 <ToolBar x:Name="toolBar" Background="#FFF7F7F7" DockPanel.Dock="Top">
                     <ComboBox x:Name="FaceFXAnimSetComboBox" Margin="0" Width="463" ItemsSource="{Binding AnimSets}"
                               SelectedItem="{Binding SelectedExport}"
@@ -84,4 +95,5 @@
             </DockPanel>
         </Grid>
     </DockPanel>
+
 </global:WPFBase>

--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXEditor.xaml.cs
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXEditor.xaml.cs
@@ -20,6 +20,8 @@ namespace ME3Explorer.FaceFX
     {
         public ObservableCollectionExtended<ExportEntry> AnimSets { get; } = new();
 
+        public string CurrentFile => Pcc != null ? Path.GetFileName(Pcc.FilePath) : "Select a file to load";
+
         private ExportEntry _selectedExport;
 
         public ExportEntry SelectedExport
@@ -123,6 +125,7 @@ namespace ME3Explorer.FaceFX
 
                 RecentsController.AddRecent(fileName, false);
                 RecentsController.SaveRecentList(true);
+                OnPropertyChanged(nameof(CurrentFile));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Display length and TLK string on the list of lines in a FaceFX Line set, similar to how Soundplorer displays audio file info.

![Screenshot 2021-03-27 214136](https://user-images.githubusercontent.com/8151477/112740034-80209100-8f47-11eb-962a-d03bed5189af.png)

Also add standard bottom bar with game and loaded Pcc information to FaceFXEditor.