### PR TITLE
FaceFXEd: Add delete phoneme keys options for #231

### DIFF
--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml
@@ -48,6 +48,7 @@
                                     <MenuItem Header="Import Section of line" Click="ImpLineSec_Click"/>
                                     <MenuItem Header="Export Section of line" Click="ExpLineSec_Click"/>
                                     <MenuItem Header="Offset keys after time" Click="OffsetKeysAfterTime_Click" />
+                                    <MenuItem Header="Clear all 'm__' lip sync keys" Click="ClearLipSyncKeys_Click"/>
                                     <MenuItem Header="Delete Line" Click="DeleteLine_Click"/>
                                 </ContextMenu>
                             </StackPanel.ContextMenu>
@@ -87,6 +88,7 @@
                         <TextBlock.ContextMenu>
                             <ContextMenu>
                                 <MenuItem Header="Delete" Click="DeleteAnim_Click"/>
+                                <MenuItem Header="Delete All Keys" Click="DeleteAnimKeys_Click"/>
                                 <MenuItem Header="Export Curve to Excel" Click="ExportToExcel_Click">
                                     <MenuItem.Icon>
                                         <Image Source="/ME3Explorer;component/Resources/excel.png" Width="16" Height="16" Margin="0,0,2,0"/>

--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml.cs
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml.cs
@@ -221,6 +221,7 @@ namespace ME3Explorer.FaceFX
                     leaveTangent = x.LeaveTangent
                 }).ToList();
                 SelectedLine.NumKeys = numKeys;
+                SelectedLineEntry.UpdateLength();
             }
             CurrentLoadedExport?.WriteBinary(FaceFX);
         }
@@ -234,6 +235,7 @@ namespace ME3Explorer.FaceFX
                     if (line.Line.NameAsString == name)
                     {
                         SelectedLineEntry = line;
+                        linesListBox.ScrollIntoView(line);
                         break;
                     }
                 }
@@ -379,6 +381,33 @@ namespace ME3Explorer.FaceFX
             Animation a = (Animation)animationListBox.SelectedItem;
             List<Animation> anims = animationListBox.ItemsSource.Cast<Animation>().ToList();
             anims.Remove(a);
+            animationListBox.ItemsSource = anims;
+            SaveChanges();
+        }
+
+        private void DeleteAnimKeys_Click(object sender, RoutedEventArgs e)
+        {
+            Animation a = (Animation)animationListBox.SelectedItem;
+            List<Animation> anims = animationListBox.ItemsSource.Cast<Animation>().ToList();
+
+            a.points = new LinkedList<CurvePoint>();
+            anims[animationListBox.SelectedIndex] = a;
+            animationListBox.ItemsSource = anims;
+            animationListBox.SelectedItem = a;
+            SaveChanges();
+        }
+
+        private void ClearLipSyncKeys_Click(object sender, RoutedEventArgs e)
+        {
+            List<Animation> anims = animationListBox.ItemsSource.Cast<Animation>().ToList();
+            for(int i = 0; i < anims.Count; i++)
+            {
+                if(anims[i].Name.StartsWith("m_"))
+                {
+                    Animation newAnim = new Animation { Name = anims[i].Name, points = new LinkedList<CurvePoint>() };
+                    anims[i] = newAnim;
+                }
+            }
             animationListBox.ItemsSource = anims;
             SaveChanges();
         }


### PR DESCRIPTION
Adds two ContextMenu items in FaceFX editor as detailed in #231. 

Adds ability to delete all keys on phonemes starting with "m_" to the line context menu, as requested by D0lphin. This is only applicable to human FaceFX in Mass Effect 3, alien lip sync and other game phonemes do not seem to start with "m_". A record of which phonemes across all games apply to lip sync would be needed to implement this feature fully.

Adds ability to delete all keys on a specific phoneme to the animation context menu.