### PR TITLE
FaceFXEd: Handle length on empty line, fixes #234

### DIFF
--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml.cs
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml.cs
@@ -811,7 +811,14 @@ namespace ME3Explorer.FaceFX
 
         public void UpdateLength()
         {
-            Length = Line.Points.Max((l) => l.time);
+            if(Line.Points.Count == 0 || Line == null)
+            {
+                Length = 0f;
+            }
+            else
+            {
+                Length = Line.Points.Max((l) => l.time);
+            }
             LengthAsString = TimeSpan.FromSeconds(Length).ToString(@"mm\:ss\:fff");
         }
     }

--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml.cs
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml.cs
@@ -811,7 +811,7 @@ namespace ME3Explorer.FaceFX
 
         public void UpdateLength()
         {
-            if(Line.Points.Count == 0 || Line == null)
+            if(Line == null || Line.Points.Count == 0)
             {
                 Length = 0f;
             }


### PR DESCRIPTION
Check if a FaceFX line has no points before setting the length, fixing issue #234.