### PR TITLE
FaceFX: Add Reference Curve, horizontal movement #233

### DIFF
--- a/ME3Explorer/CurveEd/Anchor.cs
+++ b/ME3Explorer/CurveEd/Anchor.cs
@@ -61,6 +61,14 @@ namespace ME3Explorer.CurveEd
             if (sender is Anchor a && a.graph != null)
             {
                 a.point.Value.InVal = Convert.ToSingle(a.graph.toUnrealX((double)e.NewValue));
+                if (a.IsSelected)
+                {
+                    string val = a.point.Value.InVal.ToString("0.###");
+                    if (!a.graph.xTextBox.Text.isNumericallyEqual(val))
+                    {
+                        a.graph.xTextBox.Text = val;
+                    }
+                }
             }
         }
 
@@ -265,9 +273,24 @@ namespace ME3Explorer.CurveEd
 
         private void OnDragDelta(object sender, DragDeltaEventArgs e)
         {
-            Y -= e.VerticalChange;
-            leftHandle.Y -= e.VerticalChange;
-            rightHandle.Y -= e.VerticalChange;
+            if(Keyboard.Modifiers == ModifierKeys.Shift || Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                double prev = graph.toLocalX(point.Previous?.Value.InVal ?? float.MinValue);
+                double next = graph.toLocalX(point.Next?.Value.InVal ?? float.MaxValue);
+                double change = e.HorizontalChange;
+                if ((X + change) <= prev || (X + change) >= next) change = 0f;
+
+                X += change;
+                leftHandle.X += change;
+                rightHandle.X += change;
+            }
+
+            if (Keyboard.Modifiers != ModifierKeys.Shift)
+            {
+                Y -= e.VerticalChange;
+                leftHandle.Y -= e.VerticalChange;
+                rightHandle.Y -= e.VerticalChange;
+            }
         }
     }
 }

--- a/ME3Explorer/CurveEd/CurveGraph.xaml
+++ b/ME3Explorer/CurveEd/CurveGraph.xaml
@@ -6,11 +6,14 @@
                                   xmlns:local="clr-namespace:ME3Explorer.CurveEd"
                                   xmlns:generic="clr-namespace:System.Collections.Generic;assembly=mscorlib"
                                   xmlns:me3Explorer="clr-namespace:ME3Explorer"
+                                  xmlns:converters="clr-namespace:ME3Explorer.SharedUI.Converters"
                                   mc:Ignorable="d" 
                                   DataContext="{Binding RelativeSource={RelativeSource Self}}"
                                   d:DesignHeight="300" d:DesignWidth="444.472" SizeChanged="UserControl_SizeChanged" ClipToBounds="True" MouseWheel="UserControl_MouseWheel">
     <UserControl.Resources>
-        <SolidColorBrush x:Key="CurveStrokeBrush" Color="#FFC6037D"/>
+        <converters:NullVisibilityConverter x:Key="NullVisibilityConverter"/>
+        <SolidColorBrush x:Key="CurveStrokeBrush" Color="#FFFFC603"/>
+        <SolidColorBrush x:Key="CompareCurveStrokeBrush" Color="SlateGray"/>
         <Style TargetType="{x:Type local:BezierSegment}">
             <Setter Property="StrokeThickness" Value="1"/>
             <Setter Property="Stroke" Value="{DynamicResource CurveStrokeBrush}"/>
@@ -18,6 +21,10 @@
         <Style TargetType="{x:Type Line}">
             <Setter Property="StrokeThickness" Value="1"/>
             <Setter Property="Stroke" Value="{DynamicResource CurveStrokeBrush}"/>
+        </Style>
+        <Style x:Key="CompareCurve">
+            <Setter Property="Line.Stroke" Value="{DynamicResource CompareCurveStrokeBrush}"/>
+            <Setter Property="local:BezierSegment.Stroke" Value="{DynamicResource CompareCurveStrokeBrush}"/>
         </Style>
         <Style x:Key="HandleLine" TargetType="{x:Type Line}">
             <Setter Property="StrokeThickness" Value="1"/>
@@ -45,7 +52,7 @@
             <Setter Property="Cursor" Value="Hand"/>
             <Setter Property="Panel.ZIndex" Value="2"/>
             <Setter Property="Background" Value="{DynamicResource CurveStrokeBrush}"/>
-            <Setter Property="BorderBrush" Value="#FFB00000"/>
+            <Setter Property="BorderBrush" Value="#FFCC9800"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate>
@@ -63,8 +70,8 @@
             </Setter>
             <Style.Triggers>
                 <Trigger Property="IsSelected" Value="True">
-                    <Setter Property="Background" Value="#FFF9FF06"/>
-                    <Setter Property="BorderBrush" Value="#FFEF070A"/>
+                    <Setter Property="Background" Value="White"/>
+                    <Setter Property="BorderBrush" Value="LightGray"/>
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -72,14 +79,14 @@
             <Setter Property="Canvas.Bottom" Value="{Binding Path=Y, RelativeSource={RelativeSource Self}}"/>
             <Setter Property="Canvas.Left" Value="{Binding Path=X, RelativeSource={RelativeSource Self}}"/>
             <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="Panel.ZIndex" Value="2"/>
+            <Setter Property="Panel.ZIndex" Value="3"/>
             <Setter Property="Background" Value="White"/>
             <Setter Property="Visibility" Value="Hidden"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate>
                         <Rectangle Fill="{TemplateBinding Background}" 
-                                 Width="7" Height="7"/>
+                                 Width="6" Height="6"/>
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
@@ -98,8 +105,13 @@
             <Grid.RowDefinitions>
                 <RowDefinition/>
                 <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
-            <Border Grid.Row="0" Background="#80000000" Padding="5" CornerRadius="10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Background="#80000000" Padding="5" CornerRadius="10">
                 <StackPanel Orientation="Horizontal">
                     <CheckBox x:Name="fixedTimeSpanCheckBox" VerticalAlignment="Center" IsChecked="{Binding UseFixedTimeSpan}"/>
                     <Label Content="Fixed Time Span" />
@@ -109,7 +121,14 @@
                     <TextBox x:Name="endTextBox" Width="40" Text="{Binding FixedEndTime}"/>
                 </StackPanel>
             </Border>
-            <Border Grid.Row="1" HorizontalAlignment="Right" Margin="0, 5"  Background="#80000000" Padding="5" CornerRadius="10">
+            <Border Grid.Row="1" Grid.Column="0" Height="31" VerticalAlignment="Top" Background="#80000000" Margin="0,5" Padding="5" CornerRadius="10"
+                    Visibility="{Binding ComparisonCurve, Converter={StaticResource NullVisibilityConverter}}">
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox x:Name="showReferenceCurveCheckBox" VerticalAlignment="Center" IsChecked="{Binding ShowReferenceCurve}"/>
+                    <Label Content="Reference Curve" />
+                </StackPanel>
+            </Border>
+            <Border Grid.Row="1" Grid.Column="2" HorizontalAlignment="Right" Margin="0, 5"  Background="#80000000" Padding="5" CornerRadius="10">
                 <Grid >
                     <Grid.RowDefinitions>
                         <RowDefinition />

--- a/ME3Explorer/CurveEd/CurveGraph.xaml.cs
+++ b/ME3Explorer/CurveEd/CurveGraph.xaml.cs
@@ -43,6 +43,17 @@ namespace ME3Explorer.CurveEd
             }
         }
 
+        public Curve ComparisonCurve
+        {
+            get => (Curve)GetValue(ComparisonCurveProperty);
+            set => SetValue(ComparisonCurveProperty, value);
+        }
+
+        // Using a DependencyProperty as the backing store for ComparisonCurve.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ComparisonCurveProperty =
+            DependencyProperty.Register(nameof(ComparisonCurve), typeof(Curve), typeof(CurveGraph), new PropertyMetadata());
+
+
         public CurvePoint SelectedPoint
         {
             get => (CurvePoint)GetValue(SelectedPointProperty);
@@ -161,6 +172,8 @@ namespace ME3Explorer.CurveEd
             graph.Children.Clear();
 
             LinkedList<CurvePoint> points = SelectedCurve.CurvePoints;
+
+            // Set size and scale of graph
             if (points.Count > 0 && recomputeView)
             {
                 if (UseFixedTimeSpan)
@@ -207,6 +220,7 @@ namespace ME3Explorer.CurveEd
                 VerticalScale = graph.ActualHeight / vSpan;
             }
 
+            // Render grid
             int numXLines = Convert.ToInt32(Math.Ceiling(ActualWidth / LINE_SPACING));
             int numYLines = Convert.ToInt32(Math.Ceiling(ActualHeight / LINE_SPACING));
             double upperXBound = toUnrealX(ActualWidth);
@@ -250,7 +264,24 @@ namespace ME3Explorer.CurveEd
                 graph.Children.Add(label);
             }
 
+            // Render line
+            if(ShowReferenceCurve && ComparisonCurve != null && ComparisonCurve.CurvePoints.Count > 0)
+            {
+                LinkedList<CurvePoint> comparePoints = ComparisonCurve.CurvePoints;
+                RenderLine(comparePoints, interactable: false);
+            }
+
+            RenderLine(points);
+
+            TrackLoading = false;
+        }
+
+        private void RenderLine(LinkedList<CurvePoint> points, bool interactable = true)
+        {
+            Line line;
             Anchor lastAnchor = null;
+            Style comparisonCurveStyle = FindResource("CompareCurve") as Style; // Applied to line when not interactable
+
             for (LinkedListNode<CurvePoint> node = points.First; node != null; node = node.Next)
             {
                 switch (node.Value.InterpMode)
@@ -274,19 +305,27 @@ namespace ME3Explorer.CurveEd
                 {
                     a.IsSelected = true;
                 }
+
+                if(!interactable)
+                {
+                    // Hide anchors
+                    a.Visibility = Visibility.Hidden;
+                }
+
                 graph.Children.Add(a);
 
                 if (node.Previous == null)
                 {
-                    line = new Line {X1 = -10};
+                    line = new Line { X1 = -10 };
                     line.bind(Line.Y1Property, a, nameof(Anchor.Y), new YConverter(), ActualHeight);
                     line.bind(Line.X2Property, a, nameof(Anchor.X));
                     line.bind(Line.Y2Property, a, nameof(Anchor.Y), new YConverter(), ActualHeight);
+                    if (!interactable) line.Style = comparisonCurveStyle;
                     graph.Children.Add(line);
                 }
                 else
                 {
-                    PathBetween(lastAnchor, a, node.Previous.Value.InterpMode);
+                    PathBetween(lastAnchor, a, node.Previous.Value.InterpMode, (interactable ? null : comparisonCurveStyle));
                 }
 
                 if (node.Next == null)
@@ -296,14 +335,14 @@ namespace ME3Explorer.CurveEd
                     line.bind(Line.Y1Property, a, nameof(Anchor.Y), new YConverter(), ActualHeight);
                     line.X2 = ActualWidth + 10;
                     line.bind(Line.Y2Property, a, nameof(Anchor.Y), new YConverter(), ActualHeight);
+                    if (!interactable) line.Style = comparisonCurveStyle;
                     graph.Children.Add(line);
                 }
                 lastAnchor = a;
             }
-            TrackLoading = false;
         }
 
-        private void PathBetween(Anchor a1, Anchor a2, CurveMode interpMode = CurveMode.CIM_Linear)
+        private void PathBetween(Anchor a1, Anchor a2, CurveMode interpMode = CurveMode.CIM_Linear, Style styleOverride = null)
         {
             Line line;
             switch (interpMode)
@@ -314,6 +353,7 @@ namespace ME3Explorer.CurveEd
                     line.bind(Line.Y1Property, a1, nameof(Anchor.Y), new YConverter(), ActualHeight);
                     line.bind(Line.X2Property, a2, nameof(Anchor.X));
                     line.bind(Line.Y2Property, a2, nameof(Anchor.Y), new YConverter(), ActualHeight);
+                    if (styleOverride != null) line.Style = styleOverride;
                     graph.Children.Add(line);
                     break;
                 case CurveMode.CIM_Constant:
@@ -322,12 +362,14 @@ namespace ME3Explorer.CurveEd
                     line.bind(Line.Y1Property, a1, nameof(Anchor.Y), new YConverter(), ActualHeight);
                     line.bind(Line.X2Property, a2, nameof(Anchor.X));
                     line.bind(Line.Y2Property, a1, nameof(Anchor.Y), new YConverter(), ActualHeight);
+                    if (styleOverride != null) line.Style = styleOverride;
                     graph.Children.Add(line);
                     line = new Line();
                     line.bind(Line.X1Property, a2, nameof(Anchor.X));
                     line.bind(Line.Y1Property, a1, nameof(Anchor.Y), new YConverter(), ActualHeight);
                     line.bind(Line.X2Property, a2, nameof(Anchor.X));
                     line.bind(Line.Y2Property, a2, nameof(Anchor.Y), new YConverter(), ActualHeight);
+                    if (styleOverride != null) line.Style = styleOverride;
                     graph.Children.Add(line);
                     break;
                 case CurveMode.CIM_CurveAuto:
@@ -343,6 +385,7 @@ namespace ME3Explorer.CurveEd
                     bez.bind(BezierSegment.Y1Property, a1, nameof(Anchor.Y));
                     bez.bind(BezierSegment.X2Property, a2, nameof(Anchor.X));
                     bez.bind(BezierSegment.Y2Property, a2, nameof(Anchor.Y));
+                    if(styleOverride != null) bez.Style = styleOverride;
                     graph.Children.Add(bez);
                     a1.rightBez = bez;
                     a2.leftBez = bez;
@@ -364,7 +407,23 @@ namespace ME3Explorer.CurveEd
 
         private void UserControl_MouseWheel(object sender, MouseWheelEventArgs e)
         {
-            VerticalScale *= 1 + ((double)e.Delta / 4000);
+            if(Keyboard.Modifiers == ModifierKeys.Shift)
+            {
+                if (UseFixedTimeSpan)
+                {
+                    FixedStartTime *= 1 + ((float)e.Delta / 8000);
+                    FixedEndTime *= (1 + ((float)e.Delta / 8000));
+                    return;
+                }
+                else
+                {
+                    HorizontalScale *= 1 + ((double)e.Delta / 4000);
+                }
+            }
+            else
+            {
+                VerticalScale *= 1 + ((double)e.Delta / 4000);
+            }
             //VerticalOffset += (graph.ActualHeight / VerticalScale) * 0.1 * Math.Sign(e.Delta);
             Paint();
         }
@@ -375,7 +434,8 @@ namespace ME3Explorer.CurveEd
             {
                 dragging = true;
                 dragPos = e.GetPosition(graph);
-                Cursor = Cursors.ScrollNS;
+                if (Keyboard.Modifiers == ModifierKeys.Shift) Cursor = Cursors.ScrollWE;
+                else Cursor = Cursors.ScrollNS;
             }
             else if (ReferenceEquals(e.OriginalSource, graph) && e.ChangedButton == MouseButton.Right)
             {
@@ -465,8 +525,23 @@ namespace ME3Explorer.CurveEd
             if (dragging)
             {
                 Point newPos = e.GetPosition(graph);
-                double yDiff = newPos.Y - dragPos.Y;
-                VerticalOffset += yDiff / VerticalScale;
+                if(Keyboard.Modifiers == ModifierKeys.Shift)
+                {
+                    double xDiff = newPos.X - dragPos.X;
+                    if (UseFixedTimeSpan)
+                    {
+                        FixedStartTime -= (float)(xDiff / HorizontalScale);
+                        FixedEndTime -= (float)(xDiff / HorizontalScale);
+                        dragPos = newPos;
+                        return;
+                    }
+                    HorizontalOffset -= xDiff / HorizontalScale;
+                }
+                else
+                {
+                    double yDiff = newPos.Y - dragPos.Y;
+                    VerticalOffset += yDiff / VerticalScale;
+                }
                 Paint();
                 dragPos = newPos;
             }
@@ -520,6 +595,7 @@ namespace ME3Explorer.CurveEd
                 }
             }
         }
+
         /// <summary>
         /// Find a string in the stackframes.
         /// </summary>
@@ -558,6 +634,7 @@ namespace ME3Explorer.CurveEd
         public void Clear()
         {
             SelectedCurve = new Curve();
+            ComparisonCurve = null;
             Paint(true);
             xTextBox.Clear();
             yTextBox.Clear();
@@ -598,6 +675,19 @@ namespace ME3Explorer.CurveEd
                 if (SetProperty(ref _fixedEndTime, value))
                 {
                     Paint(true);
+                }
+            }
+        }
+
+        private bool _showReferenceCurve = true;
+        public bool ShowReferenceCurve
+        {
+            get => _showReferenceCurve;
+            set
+            {
+                if (SetProperty(ref _showReferenceCurve, value))
+                {
+                    Paint();
                 }
             }
         }

--- a/ME3Explorer/CurveEd/CurveGraph.xaml.cs
+++ b/ME3Explorer/CurveEd/CurveGraph.xaml.cs
@@ -178,13 +178,7 @@ namespace ME3Explorer.CurveEd
             {
                 if (UseFixedTimeSpan)
                 {
-                    HorizontalOffset = FixedStartTime;
-                    float diff = Math.Abs(FixedEndTime - FixedStartTime); //No negative values!
-                    if (diff < 0.1f)
-                    {
-                        diff = 0.1f; //No super tiny values!
-                    }
-                    HorizontalScale = graph.ActualWidth / diff;
+                    UpdateScalingFromFixedTimeSpan();
                 }
                 else
                 {
@@ -640,6 +634,20 @@ namespace ME3Explorer.CurveEd
             yTextBox.Clear();
         }
 
+        private void UpdateScalingFromFixedTimeSpan()
+        {
+            if(UseFixedTimeSpan)
+            {
+                HorizontalOffset = FixedStartTime;
+                float diff = Math.Abs(FixedEndTime - FixedStartTime); //No negative values!
+                if (diff < 0.1f)
+                {
+                    diff = 0.1f; //No super tiny values!
+                }
+                HorizontalScale = graph.ActualWidth / diff;
+            }
+        }
+
         private bool _useFixedTimeSpan;
         public bool UseFixedTimeSpan
         {
@@ -661,7 +669,8 @@ namespace ME3Explorer.CurveEd
             {
                 if (SetProperty(ref _fixedStartTime, value))
                 {
-                    Paint(true);
+                    UpdateScalingFromFixedTimeSpan();
+                    Paint();
                 }
             }
         }
@@ -674,7 +683,8 @@ namespace ME3Explorer.CurveEd
             {
                 if (SetProperty(ref _fixedEndTime, value))
                 {
-                    Paint(true);
+                    UpdateScalingFromFixedTimeSpan();
+                    Paint();
                 }
             }
         }

--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml
@@ -33,7 +33,7 @@
                 <RowDefinition/>
                 <RowDefinition Height="155"/>
             </Grid.RowDefinitions>
-            <ListBox x:Name="linesListBox" SelectedItem="{Binding SelectedLineEntry}"
+            <ListBox x:Name="linesListBox" ItemsSource="{Binding Lines}" SelectedItem="{Binding SelectedLineEntry}"
                  AllowDrop="True" PreviewMouseLeftButtonDown="linesListBox_PreviewMouseLeftButtonDown" MouseMove="linesListBox_MouseMove"
                  DragEnter="linesListBox_DragEnter" Drop="linesListBox_Drop" HorizontalContentAlignment="Stretch" PreviewMouseRightButtonDown="linesListBox_PreviewMouseRightButtonDown">
                 <ListBox.ItemTemplate>
@@ -49,6 +49,7 @@
                                     <MenuItem Header="Export Section of line" Click="ExpLineSec_Click"/>
                                     <MenuItem Header="Offset keys after time" Click="OffsetKeysAfterTime_Click" />
                                     <MenuItem Header="Clear all 'm__' lip sync keys" Click="ClearLipSyncKeys_Click"/>
+                                    <MenuItem Header="Clone" Click="CloneLine_Click"/>
                                     <MenuItem Header="Delete Line" Click="DeleteLine_Click"/>
                                 </ContextMenu>
                             </StackPanel.ContextMenu>
@@ -78,10 +79,11 @@
         </Grid>
         <GridSplitter Grid.Row="1" Grid.RowSpan="2" Width="5" HorizontalAlignment="Stretch" Grid.Column="1"/>
         <Label Content="Animations" Grid.Row="0" Grid.Column="2"/>
-        <ListBox x:Name="animationListBox" Grid.Column="2" Grid.Row="1" SelectionChanged="animationListBox_SelectionChanged" 
+        <ListBox x:Name="animationListBox" Grid.Column="2" Grid.Row="1" ItemsSource="{Binding Animations}"
+                    SelectionChanged="animationListBox_SelectionChanged" 
                      AllowDrop="True" PreviewMouseLeftButtonDown="animationListBox_PreviewMouseLeftButtonDown" MouseMove="animationListBox_MouseMove"
                      DragEnter="animationListBox_DragEnter" Drop="animationListBox_Drop" HorizontalContentAlignment="Stretch"
-                     HorizontalAlignment="Stretch">
+                     HorizontalAlignment="Stretch" SelectedItem="{Binding SelectedAnimation}">
             <ListBox.ItemTemplate>
                 <DataTemplate DataType="{x:Type facefx:Animation}">
                     <TextBlock Text="{Binding Name}" Margin="0 0 5 0">
@@ -89,6 +91,8 @@
                             <ContextMenu>
                                 <MenuItem Header="Delete" Click="DeleteAnim_Click"/>
                                 <MenuItem Header="Delete All Keys" Click="DeleteAnimKeys_Click"/>
+                                <MenuItem Header="Set As Reference Curve" Click="SelectForCompare_Click"/>
+                                <MenuItem Header="Clone" Click="CloneAnimation_Click"/>
                                 <MenuItem Header="Export Curve to Excel" Click="ExportToExcel_Click">
                                     <MenuItem.Icon>
                                         <Image Source="/ME3Explorer;component/Resources/excel.png" Width="16" Height="16" Margin="0,0,2,0"/>
@@ -97,6 +101,11 @@
                             </ContextMenu>
                         </TextBlock.ContextMenu>
                     </TextBlock>
+                    <DataTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsReferenceAnim}" Value="True">
+                            <Setter Property="TextBlock.Foreground" Value="Blue"/>
+                        </DataTrigger>
+                    </DataTemplate.Triggers>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>

--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml.cs
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXAnimSetEditorControl.xaml.cs
@@ -62,7 +62,7 @@ namespace ME3Explorer.FaceFX
 
         public FaceFXAnimSet FaceFX;
 
-        public ObservableCollectionExtended<FaceFXLineEntry> Lines { get; set; } = new ObservableCollectionExtended<FaceFXLineEntry>();
+        public ObservableCollectionExtended<FaceFXLineEntry> Lines { get; } = new ObservableCollectionExtended<FaceFXLineEntry>();
 
         FaceFXLineEntry _selectedLineEntry;
 
@@ -83,7 +83,7 @@ namespace ME3Explorer.FaceFX
 
         public FaceFXLine SelectedLine => SelectedLineEntry?.Line;
 
-        public ObservableCollectionExtended<Animation> Animations { get; set; } = new ObservableCollectionExtended<Animation>();
+        public ObservableCollectionExtended<Animation> Animations { get; } = new ObservableCollectionExtended<Animation>();
 
         Animation _selectedAnimation;
         public Animation SelectedAnimation
@@ -99,8 +99,8 @@ namespace ME3Explorer.FaceFX
             set {
                 if(_referenceAnimation != null) _referenceAnimation.IsReferenceAnim = false;
                 SetProperty(ref _referenceAnimation, value);
-                _referenceAnimation.IsReferenceAnim = true;
-                graph.ComparisonCurve = _selectedAnimation.ToCurve(SaveChanges);
+                if(_referenceAnimation != null) _referenceAnimation.IsReferenceAnim = true;
+                graph.ComparisonCurve = _referenceAnimation?.ToCurve(SaveChanges);
                 graph.Paint();
             }
         }
@@ -380,7 +380,7 @@ namespace ME3Explorer.FaceFX
                 if (CurrentLoadedExport == null || d.fromFile == CurrentLoadedExport.FileRef.FilePath) return;
 
                 Animations.Add(d.anim);
-                SelectedLine.AnimationNames.Add(FaceFX.Names.FindOrAdd(d.anim.Name));
+                FaceFX.Names.FindOrAdd(d.anim.Name);
                 SaveChanges();
                 UpdateAnimListBox();
             }

--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXEditor.xaml
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXEditor.xaml
@@ -23,7 +23,7 @@
     </Window.InputBindings>
     <DockPanel>
         <Menu DockPanel.Dock="Top">
-            <MenuItem Header="_File">
+            <MenuItem Header="_File" Padding="4">
                 <MenuItem Header="_Open" Command="{Binding OpenCommand}" InputGestureText="Ctrl+O" ToolTip="Open a package file"/>
                 <MenuItem Header="_Save"  Command="{Binding SaveCommand}" InputGestureText="Ctrl+S" ToolTip="Save package file in-place"/>
                 <MenuItem Header="Save as" Command="{Binding SaveAsCommand}" InputGestureText="Ctrl+Shift+S" ToolTip="Save package file to another location"/>

--- a/ME3Explorer/FaceFXAnimSetEditor/FaceFXEditor.xaml.cs
+++ b/ME3Explorer/FaceFXAnimSetEditor/FaceFXEditor.xaml.cs
@@ -100,7 +100,6 @@ namespace ME3Explorer.FaceFX
                 try
                 {
                     LoadFile(d.FileName);
-                    Title = $"FaceFXEditor - {Pcc.FilePath}";
                 }
                 catch (Exception ex)
                 {
@@ -123,6 +122,7 @@ namespace ME3Explorer.FaceFX
                 editorControl.UnloadExport();
                 RefreshComboBox();
 
+                Title = $"FaceFX Editor - {Pcc.FilePath}";
                 RecentsController.AddRecent(fileName, false);
                 RecentsController.SaveRecentList(true);
                 OnPropertyChanged(nameof(CurrentFile));


### PR DESCRIPTION
Implement most of the feature requests from #233, and some other small changes to FaceFX editor.

![image](https://user-images.githubusercontent.com/8151477/113521725-60055900-9569-11eb-85e8-3eddfce4bb44.png)

Big Changes:
- Select a reference animation by right clicking in the animation list, will show up underneath any other animation from that line. Toggle-able once selected.
- Drag-and-drop behavior in FaceFX Editor now works like Package Editor. You can now only drag and drop between two different windows. To copy within a file, you can Right Click > Clone on an animation or line.
- You can now drag a key horizontally by holding shift, or in both directions at the same time by holding control. (Todo: Find some way of communicating this to the user)
- Recolor of the CurveGraph to be higher contrast and easier on the eyes.
- Most movement & scaling click-and-drag operations inside curve graph now work horizontally by holding shift. This is a bit laggy with Fixed Time Span turned on, and could be optimized further.
- Animation and Lines listboxes now use ObservableCollectionExtended collections and data binding.
