### PR TITLE
Add experiments to create preset director and camera InterpGroups

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -9,9 +9,11 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
+using LegendaryExplorer.Dialogs;
 using LegendaryExplorer.Misc;
 using LegendaryExplorerCore.Helpers;
 using LegendaryExplorerCore.GameFilesystem;
+using LegendaryExplorerCore.Matinee;
 using LegendaryExplorerCore.Misc;
 using LegendaryExplorerCore.Packages;
 using LegendaryExplorerCore.TLK.ME1;
@@ -432,6 +434,39 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
             var toc = new TOCBinFile(inputFile);
             toc.DumpTOCToTxtFile(outputFile);
+        }
+
+        public static void AddPresetGroup(string preset, PackageEditorWindow pew)
+        {
+            if (pew.SelectedItem.Entry.ClassName != "InterpData")
+            {
+                MessageBox.Show("InterpData not selected.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            if (pew.SelectedItem.Entry is not ExportEntry interp)
+                return;
+
+            switch (preset)
+            {
+                case "Director":
+                    MatineeHelper.AddPresetDirectorGroup(interp);
+                    break;
+
+                case "Camera":
+                    if (PromptDialog.Prompt(null, "Name of camera actor:") is string camName)
+                    {
+                        if (string.IsNullOrEmpty(camName))
+                        {
+                            MessageBox.Show("Not a valid camera actor name.", "Warning", MessageBoxButton.OK);
+                            return;
+                        }
+                        MatineeHelper.AddPresetCameraGroup(interp, camName);
+                    }
+                    break;
+            }
+
+            return;
         }
     }
 }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -471,5 +471,36 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             }
             return;
         }
+
+        public static void AddPresetTrack(string preset, PackageEditorWindow pew)
+        {
+            if (pew.SelectedItem != null && pew.SelectedItem.Entry != null)
+            {
+                if (pew.SelectedItem.Entry.ClassName != "InterpGroup")
+                {
+                    MessageBox.Show("InterpGroup not selected.", "Warning", MessageBoxButton.OK);
+                    return;
+                }
+
+                if (pew.SelectedItem.Entry is not ExportEntry interp)
+                    return;
+
+                switch (preset)
+                {
+                    case "Gesture":
+                        if (PromptDialog.Prompt(null, "Name of gesture actor:") is string actor)
+                        {
+                            if (string.IsNullOrEmpty(actor))
+                            {
+                                MessageBox.Show("Not a valid gesture actor name.", "Warning", MessageBoxButton.OK);
+                                return;
+                            }
+                            MatineeHelper.AddPresetGestureTrack(interp, actor);
+                        }
+                        break;
+                }
+            }
+            return;
+        }
     }
 }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -438,34 +438,37 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
         public static void AddPresetGroup(string preset, PackageEditorWindow pew)
         {
-            if (pew.SelectedItem.Entry.ClassName != "InterpData")
+            if (pew.SelectedItem != null && pew.SelectedItem.Entry != null)
             {
-                MessageBox.Show("InterpData not selected.", "Warning", MessageBoxButton.OK);
-                return;
-            }
 
-            if (pew.SelectedItem.Entry is not ExportEntry interp)
-                return;
+                if (pew.SelectedItem.Entry.ClassName != "InterpData")
+                {
+                    MessageBox.Show("InterpData not selected.", "Warning", MessageBoxButton.OK);
+                    return;
+                }
 
-            switch (preset)
-            {
-                case "Director":
-                    MatineeHelper.AddPresetDirectorGroup(interp);
-                    break;
+                if (pew.SelectedItem.Entry is not ExportEntry interp)
+                    return;
 
-                case "Camera":
-                    if (PromptDialog.Prompt(null, "Name of camera actor:") is string camName)
-                    {
-                        if (string.IsNullOrEmpty(camName))
+                switch (preset)
+                {
+                    case "Director":
+                        MatineeHelper.AddPresetDirectorGroup(interp);
+                        break;
+
+                    case "Camera":
+                        if (PromptDialog.Prompt(null, "Name of camera actor:") is string camName)
                         {
-                            MessageBox.Show("Not a valid camera actor name.", "Warning", MessageBoxButton.OK);
-                            return;
+                            if (string.IsNullOrEmpty(camName))
+                            {
+                                MessageBox.Show("Not a valid camera actor name.", "Warning", MessageBoxButton.OK);
+                                return;
+                            }
+                            MatineeHelper.AddPresetCameraGroup(interp, camName);
                         }
-                        MatineeHelper.AddPresetCameraGroup(interp, camName);
-                    }
-                    break;
+                        break;
+                }
             }
-
             return;
         }
     }

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -124,5 +124,7 @@
         <MenuItem Header="Create test TLK from XML with IDs in string" Click="CreateTestTLKWithStringIDs_Click"/>
         <MenuItem Header="Relink Children Tree and Update Local Functions" ToolTip="Must have UStruct selected (Class, State, Function, Struct, ScriptStruct)" Click="UpdateLocalFunctions_Click"/>
         <MenuItem Header="Dump TOC file" Click="DumpTOC_Click"/>
+        <MenuItem Header="Add Preset Director InterpGroup" Click="AddPresetDirectorGroup_Click"/>
+        <MenuItem Header="Add Preset Camera InterpGroup" Click="AddPresetCameraGroup_Click"/>
     </MenuItem>
 </MenuItem>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -126,5 +126,6 @@
         <MenuItem Header="Dump TOC file" Click="DumpTOC_Click"/>
         <MenuItem Header="Add Preset Director InterpGroup" Click="AddPresetDirectorGroup_Click"/>
         <MenuItem Header="Add Preset Camera InterpGroup" Click="AddPresetCameraGroup_Click"/>
+        <MenuItem Header="Add Preset Gesture Track" Click="AddPresetGestureTrack_Click"/>
     </MenuItem>
 </MenuItem>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
@@ -1206,6 +1206,11 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
         {
             PackageEditorExperimentsO.AddPresetGroup("Camera", GetPEWindow());
         }
+
+        private void AddPresetGestureTrack_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.AddPresetTrack("Gesture", GetPEWindow());
+        }
         #endregion
 
 

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
@@ -1196,6 +1196,16 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
         {
             PackageEditorExperimentsO.DumpTOC();
         }
+
+        private void AddPresetDirectorGroup_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.AddPresetGroup("Director", GetPEWindow());
+        }
+
+        private void AddPresetCameraGroup_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.AddPresetGroup("Camera", GetPEWindow());
+        }
         #endregion
 
 

--- a/LegendaryExplorer/LegendaryExplorerCore/Matinee/MatineeHelper.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Matinee/MatineeHelper.cs
@@ -17,6 +17,10 @@ namespace LegendaryExplorerCore.Matinee
 
         public static ExportEntry AddNewGroupDirectorToInterpData(ExportEntry interpData) => InternalAddGroup("InterpGroupDirector", interpData, null);
 
+        public static ExportEntry AddPresetDirectorGroup(ExportEntry interpData) => InternalAddPresetGroup("Director", interpData);
+
+        public static ExportEntry AddPresetCameraGroup(ExportEntry interpData, string camName) => InternalAddPresetGroup("Camera", interpData, camName);
+
         private static ExportEntry InternalAddGroup(string className, ExportEntry interpData, string groupName)
         {
             var properties = new PropertyCollection{new ArrayProperty<ObjectProperty>("InterpTracks")};
@@ -34,6 +38,76 @@ namespace LegendaryExplorerCore.Matinee
             interpData.WriteProperties(props);
 
             return group;
+        }
+
+        private static ExportEntry InternalAddPresetGroup(string preset, ExportEntry interpData, string? camName = null)
+        {
+            var group = PresetCreateNewExport(preset, interpData, camName);
+            PresetAddTracks(preset, group);
+
+            return group;
+        }
+
+        private static ExportEntry PresetCreateNewExport(string preset, ExportEntry interpData, string? camName = null)
+        {
+            string className = "InterpGroup";
+            var properties = new PropertyCollection { new ArrayProperty<ObjectProperty>("InterpTracks") };
+
+            switch (preset)
+            {
+                case "Camera":
+                    if (!string.IsNullOrEmpty(camName))
+                    {
+                        properties.Add(new NameProperty(camName, "m_nmSFXFindActor"));
+                        properties.Add(new NameProperty(camName, "GroupName"));
+                    }
+                    properties.Add(CommonStructs.ColorProp(Color.Green, "GroupColor"));
+                    break;
+
+                case "Director":
+                    className = "InterpGroupDirector";
+                    properties.Add(CommonStructs.ColorProp(Color.Purple, "GroupColor"));
+                    break;
+
+                default:
+                    properties.Add(CommonStructs.ColorProp(Color.Green, "GroupColor"));
+                    break;
+            }
+
+            ExportEntry group = CreateNewExport(className, interpData, properties);
+
+            var props = interpData.GetProperties();
+            var groupsProp = props.GetProp<ArrayProperty<ObjectProperty>>("InterpGroups") ?? new ArrayProperty<ObjectProperty>("InterpGroups");
+            groupsProp.Add(new ObjectProperty(group));
+            props.AddOrReplaceProp(groupsProp);
+            interpData.WriteProperties(props);
+
+            return group;
+        }
+
+        private static void PresetAddTracks(string preset, ExportEntry group)
+        {
+            switch (preset)
+            {
+                case "Camera":
+                    var move = AddNewTrackToGroup(group, "InterpTrackMove");
+                    AddDefaultPropertiesToTrack(move);
+
+                    var fov = AddNewTrackToGroup(group, "InterpTrackFloatProp");
+                    fov.WriteProperty(new InterpCurveFloat().ToStructProperty(fov.Game, "FloatTrack"));
+                    fov.WriteProperty(new StrProperty("FOVAngle", "TrackTitle"));
+                    fov.WriteProperty(new NameProperty("FOVAngle", "PropertyName"));
+                    break;
+
+                case "Director":
+                    var dir = AddNewTrackToGroup(group, "InterpTrackDirector");
+                    AddDefaultPropertiesToTrack(dir);
+
+                    var dof = AddNewTrackToGroup(group, "BioEvtSysTrackDOF");
+                    AddDefaultPropertiesToTrack(dof);
+                    break;
+            }
+            return;
         }
 
         private static ExportEntry CreateNewExport(string className, ExportEntry parent, PropertyCollection properties)

--- a/LegendaryExplorer/LegendaryExplorerCore/Matinee/MatineeHelper.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Matinee/MatineeHelper.cs
@@ -19,7 +19,9 @@ namespace LegendaryExplorerCore.Matinee
 
         public static ExportEntry AddPresetDirectorGroup(ExportEntry interpData) => InternalAddPresetGroup("Director", interpData);
 
-        public static ExportEntry AddPresetCameraGroup(ExportEntry interpData, string camName) => InternalAddPresetGroup("Camera", interpData, camName);
+        public static ExportEntry AddPresetCameraGroup(ExportEntry interpData, string param1) => InternalAddPresetGroup("Camera", interpData, param1);
+
+        public static ExportEntry AddPresetGestureTrack(ExportEntry interpGroup, string param1) => InternalAddPresetTrack("Gesture", interpGroup, param1);
 
         private static ExportEntry InternalAddGroup(string className, ExportEntry interpData, string groupName)
         {
@@ -40,15 +42,21 @@ namespace LegendaryExplorerCore.Matinee
             return group;
         }
 
-        private static ExportEntry InternalAddPresetGroup(string preset, ExportEntry interpData, string? camName = null)
+        private static ExportEntry InternalAddPresetGroup(string preset, ExportEntry interpData, string? param1 = null)
         {
-            var group = PresetCreateNewExport(preset, interpData, camName);
-            PresetAddTracks(preset, group);
+            var group = PresetCreateNewExport(preset, interpData, param1);
+            PresetAddTracks(preset, group, param1);
 
             return group;
         }
 
-        private static ExportEntry PresetCreateNewExport(string preset, ExportEntry interpData, string? camName = null)
+        private static ExportEntry InternalAddPresetTrack(string preset, ExportEntry interpGroup, string? param1 = null)
+        {
+            PresetAddTracks(preset, interpGroup, param1);
+            return interpGroup;
+        }
+
+        private static ExportEntry PresetCreateNewExport(string preset, ExportEntry interpData, string param1)
         {
             string className = "InterpGroup";
             var properties = new PropertyCollection { new ArrayProperty<ObjectProperty>("InterpTracks") };
@@ -56,10 +64,10 @@ namespace LegendaryExplorerCore.Matinee
             switch (preset)
             {
                 case "Camera":
-                    if (!string.IsNullOrEmpty(camName))
+                    if (!string.IsNullOrEmpty(param1))
                     {
-                        properties.Add(new NameProperty(camName, "m_nmSFXFindActor"));
-                        properties.Add(new NameProperty(camName, "GroupName"));
+                        properties.Add(new NameProperty(param1, "m_nmSFXFindActor"));
+                        properties.Add(new NameProperty(param1, "GroupName"));
                     }
                     properties.Add(CommonStructs.ColorProp(Color.Green, "GroupColor"));
                     break;
@@ -85,7 +93,7 @@ namespace LegendaryExplorerCore.Matinee
             return group;
         }
 
-        private static void PresetAddTracks(string preset, ExportEntry group)
+        private static void PresetAddTracks(string preset, ExportEntry group, string? param1 = null)
         {
             switch (preset)
             {
@@ -105,6 +113,20 @@ namespace LegendaryExplorerCore.Matinee
 
                     var dof = AddNewTrackToGroup(group, "BioEvtSysTrackDOF");
                     AddDefaultPropertiesToTrack(dof);
+                    break;
+
+                case "Gesture":
+                    var ges = AddNewTrackToGroup(group, "BioEvtSysTrackGesture");
+                    ges.WriteProperty(new ArrayProperty<StructProperty>("m_aGestures"));
+                    ges.WriteProperty(new ArrayProperty<StructProperty>("m_aTrackKeys"));
+                    ges.WriteProperty(new NameProperty("None", "nmStartingPoseSet"));
+                    ges.WriteProperty(new NameProperty("None", "nmStartingPoseAnim"));
+                    ges.WriteProperty(new FloatProperty(0, "m_fStartPoseOffset"));
+                    ges.WriteProperty(new EnumProperty("None", "EBioTrackAllPoseGroups", MEGame.LE3, "ePoseFilter"));
+                    ges.WriteProperty(new EnumProperty("None", "EBioGestureAllPoses", MEGame.LE3, "eStartingPose"));
+                    ges.WriteProperty(new BoolProperty(true, "m_bUseDynamicAnimSets"));
+                    ges.WriteProperty(new NameProperty(param1, "m_nmFindActor"));
+                    ges.WriteProperty(new StrProperty("Gesture -- " + param1, "TrackTitle"));
                     break;
             }
             return;


### PR DESCRIPTION
When doing camera modding, every time you want to add new matinee camera controls to an InterpData that didn't have them you have to repeatedly add the same InterpGroups with the same basic InterpTracks and the same properties. I've added two new experiment buttons to make this process automatic.