### PR TITLE
PEExperiments: 1. Copy/Paste properties of instance. 2. Copy BMO/MIC mat into opposite. 3. Remove SM references.

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -159,6 +159,9 @@
         <MenuItem Header="Batch Add/Modify Materials' Parameters" Click="BatchPatchMaterialsParameters_Click" ToolTip="Batch add/modify a list of vector or scalar parameters in a list of given materials to all files in a given DLC folder."/>
         <MenuItem Header="Batch Set Bool Property Value" Click="BatchSetBoolPropVal_Click" ToolTip="Batch set the value of a boolean property to all given classes in a given DLC folder."/>
         <MenuItem Header="The Baldinator" Click="Baldinator_Click" ToolTip="Modify the hair morph targets of a male headmorph to make it bald."/>
+        <MenuItem Header="Copy Property" Click="CopyProperty_Click" ToolTip="Copy the selected property to another export of the same class."/>
+        <MenuItem Header="Copy Material to BioMaterialOverrides or MaterialInstanceConstants" Click="CopyMatToBMOorMIC_Click" ToolTip="Copies the texture, vector, and scalar properties of a BioMaterialOverride into [Bio]MaterialInstanceConstants, or vice-versa."/>
+        <MenuItem Header="Remove References to SkeletalMesh or StaticMesh in Distance" Click="SMRefRemover_Click" ToolTip="Removes SMC references to a SkeletalMesh or StaticMesh within a given distance"/>
     </MenuItem>
     <MenuItem Header="Object Database">
         <MenuItem Header="Build ME1 Object Database" Click="ChonkyDB_BuildME1GameDB"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
@@ -1086,7 +1086,7 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
                         EnumerateChildNetIndexes(funcbin.Children);
                         EnumerateChildNetIndexes(funcbin.Next);
                     }
-                    else if(childbin is UState statebin)
+                    else if (childbin is UState statebin)
                     {
                         EnumerateChildNetIndexes(statebin.Children);
                         EnumerateChildNetIndexes(statebin.Next);
@@ -1309,6 +1309,21 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
         private void Baldinator_Click(object sender, RoutedEventArgs a)
         {
             PackageEditorExperimentsO.Baldinator(GetPEWindow());
+        }
+
+        private void CopyProperty_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.CopyProperty(GetPEWindow());
+        }
+
+        private void CopyMatToBMOorMIC_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.CopyMatToBMOorMIC(GetPEWindow());
+        }
+
+        private void SMRefRemover_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.SMRefRemover(GetPEWindow());
         }
         #endregion
 


### PR DESCRIPTION
This branch has three experiments:
1. Experiment to copy any property from a selected export into another export of the same class.
2. Experiment to copy the material properties of a BioMaterialOverrides or MaterialInstanceConstant into an export of the opposite class.
3. Experiment to remove the [Static/Skeletal]MeshComponent references to a [Static/Skeletal]Mesh that are within a given distance from a given origin.