### PR TITLE
Sequence Editor Experiments

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
@@ -12,104 +12,94 @@ using System.Linq;
 using System.Windows;
 using static LegendaryExplorerCore.Kismet.SeqTools;
 
-namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
-{
+namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
     /// <summary>
     /// Experiments in Sequence Editor (Exkywor's stuff)
     /// </summary>
-    public static class SequenceEditorExperimentsE
-    {
-        public static void AddMissingVarLinks(SequenceEditorWPF sew)
-        {
+    public static class SequenceEditorExperimentsE {
+        /// <summary>
+        /// Updates the variable links of the selected Interp. Removes links that no longer have a matching InterpGroup,
+        /// adds links for new groups, and keeps groups that remaing the same.
+        /// </summary>
+        /// <param name="sew">Sequence Editor window.</param>
+        public static void UpdateVarLinks(SequenceEditorWPF sew) {
             if (sew.Pcc == null || sew.SelectedItem == null || sew.SelectedItem.Entry == null) { return; }
 
-            if (!sew.SelectedObjects.HasExactly(1))
-            {
+            if (!sew.SelectedObjects.HasExactly(1)) {
                 ShowError("Select only one Interp object");
                 return;
             }
 
             ExportEntry interp = sew.SelectedObjects[0].Export;
-            if (interp.ClassName != "SeqAct_Interp")
-            {
+            if (interp.ClassName != "SeqAct_Interp") {
                 ShowError("Selected object is not a SeqAct_Interp");
                 return;
             }
 
-            List<VarLinkInfo> varLinks = GetVariableLinksOfNode(interp);
-            if (varLinks.Count == 0)
-            {
+            // We get a list of StructProperties instead of VarLinkInfo because we want to keep existing ones intact
+            List<StructProperty> varLinks = interp.GetProperty<ArrayProperty<StructProperty>>("VariableLinks").ToList();
+            if (varLinks == null) {
                 ShowError("The selected Interp contains no VariableLinks");
                 return;
             }
 
-            List<VarLinkInfo> dataLinks = varLinks.Where(link => link.LinkDesc == "Data").ToList();
-            if (!dataLinks.Any())
-            {
+            List<StructProperty> dataLinks = varLinks.Where(link => link.GetProp<StrProperty>("LinkDesc").Value == "Data").ToList();
+            if (!dataLinks.Any()) {
                 ShowError("The selected Interp contains no Data variable link");
                 return;
             }
 
-            VarLinkInfo data = dataLinks.FirstOrDefault();
-            if (data == null || data.LinkedNodes.Count == 0)
-            {
+            ObjectProperty dataObj = dataLinks.First().GetProp<ArrayProperty<ObjectProperty>>("LinkedVariables").FirstOrDefault();
+            if (dataObj == null) {
                 ShowError("No InterpDatas were linked to the Data variable link");
                 return;
             }
+            ExportEntry interpData = sew.Pcc.GetUExport(dataObj.Value);
 
-            ExportEntry interpData = (ExportEntry)data.LinkedNodes.First();
-            if (interpData.ClassName != "InterpData")
-            {
+            if (interpData.ClassName != "InterpData") {
                 ShowError("The first object linked to the Data variable link is not an InterpData");
                 return;
             }
 
+            // Don't check if there are no InterpGroups, since an update could be to remove all of them
             ArrayProperty<ObjectProperty> interpGroups = interpData.GetProperty<ArrayProperty<ObjectProperty>>("InterpGroups");
-            if (interpGroups == null || interpGroups.Count == 0)
-            {
-                MessageBox.Show("No InterpGroups were found in the InterpData", "Success", MessageBoxButton.OK);
-            }
 
-            List<string> groupNames = interpGroups.Where(id =>
-            {
+            List<string> groupNames = new();
+            // We want to keep the Data and Anchor links
+            groupNames.Add("Data");
+            groupNames.Add("Anchor");
+
+            groupNames.AddRange(interpGroups.Where(id => {
                 ExportEntry group = null;
                 if (!sew.Pcc.TryGetUExport(id.Value, out group)) { return false; }
 
                 return group.GetProperty<NameProperty>("GroupName") != null;
-            }).Select(id =>
-            {
+            }).Select(id => {
                 ExportEntry group = sew.Pcc.GetUExport(id.Value);
                 return group.GetProperty<NameProperty>("GroupName").Value.Name;
-            }).Distinct().ToList();
+            }).Distinct().ToList());
 
-            if (groupNames.Count == 0)
-            {
-                MessageBox.Show("No InterpGroups contained a GroupName", "Success", MessageBoxButton.OK);
-                return;
-            }
-
-            List<StructProperty> missingLinks = groupNames
-                .Where(name => !varLinks.Any(link => string.Equals(link.LinkDesc, name, StringComparison.OrdinalIgnoreCase)))
-                .Select(name =>
-                {
+            List<StructProperty> updatedLinks = new();
+            foreach (string name in groupNames) {
+                // Keep existing varLinks if they are the default Data or Anchor, or if it already exists in the list, and add new links.
+                StructProperty varLink = varLinks.Find(link => string.Equals(link.GetProp<StrProperty>("LinkDesc").Value, name, StringComparison.OrdinalIgnoreCase));
+                if (varLink != null) {
+                    updatedLinks.Add(varLink);
+                } else {
                     PropertyCollection props = GlobalUnrealObjectInfo.getDefaultStructValue(sew.Pcc.Game, "SeqVarLink", true);
                     props.AddOrReplaceProp(new StrProperty(name, "LinKDesc"));
                     int index = sew.Pcc.FindImport("Engine.SeqVar_Object").UIndex;
                     props.AddOrReplaceProp(new ObjectProperty(index, "ExpectedType"));
-                    return new StructProperty("SeqVarLink", props);
-                }).ToList();
-
-            if (missingLinks.Count == 0)
-            {
-                MessageBox.Show("No missing variable links were found", "Success", MessageBoxButton.OK);
-                return;
+                    updatedLinks.Add(new StructProperty("SeqVarLink", props));
+                }
             }
 
-            ArrayProperty<StructProperty> variableLinksProp = interp.GetProperty<ArrayProperty<StructProperty>>("VariableLinks");
-            missingLinks.ForEach(link => variableLinksProp.Add(link));
+            KismetHelper.RemoveVariableLinks(interp); // Clear the variable links
+            ArrayProperty<StructProperty> variableLinksProp = new ArrayProperty<StructProperty>("VariableLinks");
+            updatedLinks.ForEach(link => variableLinksProp.Add(link));
             interp.WriteProperty(variableLinksProp);
 
-            MessageBox.Show($"Missing variable links added", "Success", MessageBoxButton.OK);
+            MessageBox.Show($"Variable links updated", "Success", MessageBoxButton.OK);
         }
 
         /// <summary>
@@ -117,8 +107,7 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
         /// </summary>
         /// <param name="sew">Current SE instance.</param>
         /// <param name="wantDir">True to add director template, false for camera template.</param>
-        public static void AddDialogueWheelTemplate(SequenceEditorWPF sew, bool wantDir = false)
-        {
+        public static void AddDialogueWheelTemplate(SequenceEditorWPF sew, bool wantDir = false) {
             if (sew.Pcc == null || sew.SelectedSequence == null) { return; }
 
             string camActor = promptForActor($"Name of camera actor to {(wantDir ? "control" : "add")}:", "Not a valid camera actor name.");
@@ -156,30 +145,25 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
             KismetHelper.AddObjectToSequence(interpData, sew.SelectedSequence);
             KismetHelper.CreateVariableLink(interp, "Data", interpData);
 
-            if (wantDir)
-            {
+            if (wantDir) {
                 MatineeHelper.AddPreset("Director", interpData, sew.Pcc.Game);
                 ExportEntry camGroup = MatineeHelper.AddNewGroupToInterpData(interpData, camActor);
                 camGroup.WriteProperty(new NameProperty(camActor, "m_nmSFXFindActor"));
-            } else
-            {
+            }
+            else {
                 MatineeHelper.AddPreset("Camera", interpData, sew.Pcc.Game, camActor);
             }
 
             MessageBox.Show($"Added dialogue wheel {(wantDir ? "director" : "camera")} template", "Success", MessageBoxButton.OK);
         }
 
-        private static void ShowError(string errMsg)
-        {
+        private static void ShowError(string errMsg) {
             MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
         }
 
-        private static string promptForActor(string msg, string err)
-        {
-            if (PromptDialog.Prompt(null, msg) is string actor)
-            {
-                if (string.IsNullOrEmpty(actor))
-                {
+        private static string promptForActor(string msg, string err) {
+            if (PromptDialog.Prompt(null, msg) is string actor) {
+                if (string.IsNullOrEmpty(actor)) {
                     MessageBox.Show(err, "Warning", MessageBoxButton.OK);
                     return null;
                 }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
@@ -103,6 +103,8 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
                     props.AddOrReplaceProp(new StrProperty(name, "LinKDesc"));
                     int index = sew.Pcc.FindImport("Engine.SeqVar_Object").UIndex;
                     props.AddOrReplaceProp(new ObjectProperty(index, "ExpectedType"));
+                    props.AddOrReplaceProp(new IntProperty(1, "MinVars"));
+                    props.AddOrReplaceProp(new IntProperty(255, "MaxVars"));
                     updatedLinks.Add(new StructProperty("SeqVarLink", props));
                 }
             }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
@@ -139,6 +139,9 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
             interp.RemoveProperty("OutputLinks");
 
             ExportEntry interpData = SequenceObjectCreator.CreateSequenceObject(sew.Pcc, "InterpData", cache);
+            PropertyCollection interpDataProps = new PropertyCollection();
+            interpDataProps.AddOrReplaceProp(new FloatProperty(20, "InterpLength"));
+            interpData.WriteProperties(interpDataProps);
 
             // Add the objects to the sequence
             KismetHelper.AddObjectToSequence(interp, sew.SelectedSequence);

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
@@ -1,0 +1,191 @@
+﻿
+using LegendaryExplorer.Dialogs;
+using LegendaryExplorerCore.Helpers;
+using LegendaryExplorerCore.Kismet;
+using LegendaryExplorerCore.Matinee;
+using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Unreal;
+using LegendaryExplorerCore.Unreal.ObjectInfo;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using static LegendaryExplorerCore.Kismet.SeqTools;
+
+namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
+{
+    /// <summary>
+    /// Experiments in Sequence Editor (Exkywor's stuff)
+    /// </summary>
+    public static class SequenceEditorExperimentsE
+    {
+        public static void AddMissingVarLinks(SequenceEditorWPF sew)
+        {
+            if (sew.Pcc == null || sew.SelectedItem == null || sew.SelectedItem.Entry == null) { return; }
+
+            if (!sew.SelectedObjects.HasExactly(1))
+            {
+                ShowError("Select only one Interp object");
+                return;
+            }
+
+            ExportEntry interp = sew.SelectedObjects[0].Export;
+            if (interp.ClassName != "SeqAct_Interp")
+            {
+                ShowError("Selected object is not a SeqAct_Interp");
+                return;
+            }
+
+            List<VarLinkInfo> varLinks = GetVariableLinksOfNode(interp);
+            if (varLinks.Count == 0)
+            {
+                ShowError("The selected Interp contains no VariableLinks");
+                return;
+            }
+
+            List<VarLinkInfo> dataLinks = varLinks.Where(link => link.LinkDesc == "Data").ToList();
+            if (!dataLinks.Any())
+            {
+                ShowError("The selected Interp contains no Data variable link");
+                return;
+            }
+
+            VarLinkInfo data = dataLinks.FirstOrDefault();
+            if (data == null || data.LinkedNodes.Count == 0)
+            {
+                ShowError("No InterpDatas were linked to the Data variable link");
+                return;
+            }
+
+            ExportEntry interpData = (ExportEntry)data.LinkedNodes.First();
+            if (interpData.ClassName != "InterpData")
+            {
+                ShowError("The first object linked to the Data variable link is not an InterpData");
+                return;
+            }
+
+            ArrayProperty<ObjectProperty> interpGroups = interpData.GetProperty<ArrayProperty<ObjectProperty>>("InterpGroups");
+            if (interpGroups == null || interpGroups.Count == 0)
+            {
+                MessageBox.Show("No InterpGroups were found in the InterpData", "Success", MessageBoxButton.OK);
+            }
+
+            List<string> groupNames = interpGroups.Where(id =>
+            {
+                ExportEntry group = null;
+                if (!sew.Pcc.TryGetUExport(id.Value, out group)) { return false; }
+
+                return group.GetProperty<NameProperty>("GroupName") != null;
+            }).Select(id =>
+            {
+                ExportEntry group = sew.Pcc.GetUExport(id.Value);
+                return group.GetProperty<NameProperty>("GroupName").Value.Name;
+            }).Distinct().ToList();
+
+            if (groupNames.Count == 0)
+            {
+                MessageBox.Show("No InterpGroups contained a GroupName", "Success", MessageBoxButton.OK);
+                return;
+            }
+
+            List<StructProperty> missingLinks = groupNames
+                .Where(name => !varLinks.Any(link => string.Equals(link.LinkDesc, name, StringComparison.OrdinalIgnoreCase)))
+                .Select(name =>
+                {
+                    PropertyCollection props = GlobalUnrealObjectInfo.getDefaultStructValue(sew.Pcc.Game, "SeqVarLink", true);
+                    props.AddOrReplaceProp(new StrProperty(name, "LinKDesc"));
+                    int index = sew.Pcc.FindImport("Engine.SeqVar_Object").UIndex;
+                    props.AddOrReplaceProp(new ObjectProperty(index, "ExpectedType"));
+                    return new StructProperty("SeqVarLink", props);
+                }).ToList();
+
+            if (missingLinks.Count == 0)
+            {
+                MessageBox.Show("No missing variable links were found", "Success", MessageBoxButton.OK);
+                return;
+            }
+
+            ArrayProperty<StructProperty> variableLinksProp = interp.GetProperty<ArrayProperty<StructProperty>>("VariableLinks");
+            missingLinks.ForEach(link => variableLinksProp.Add(link));
+            interp.WriteProperty(variableLinksProp);
+
+            MessageBox.Show($"Missing variable links added", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Adds an Interp and an InterpData template to control a dialogue wheel director or camera.
+        /// </summary>
+        /// <param name="sew">Current SE instance.</param>
+        /// <param name="wantDir">True to add director template, false for camera template.</param>
+        public static void AddDialogueWheelTemplate(SequenceEditorWPF sew, bool wantDir = false)
+        {
+            if (sew.Pcc == null || sew.SelectedSequence == null) { return; }
+
+            string camActor = promptForActor($"Name of camera actor to {(wantDir ? "control" : "add")}:", "Not a valid camera actor name.");
+
+            PackageCache cache = new();
+
+            // Add the interp with the required properties
+            ExportEntry interp = SequenceObjectCreator.CreateSequenceObject(sew.Pcc, "SeqAct_Interp", cache);
+            PropertyCollection interpProps = interp.GetProperties();
+
+            ArrayProperty<StructProperty> variableLinks = interp.GetProperty<ArrayProperty<StructProperty>>("VariableLinks");
+            // Add camera varLink
+            PropertyCollection camProps = GlobalUnrealObjectInfo.getDefaultStructValue(sew.Pcc.Game, "SeqVarLink", true);
+            camProps.AddOrReplaceProp(new StrProperty(camActor, "LinKDesc"));
+            int objIdx = sew.Pcc.FindImport("Engine.SeqVar_Object").UIndex;
+            camProps.AddOrReplaceProp(new ObjectProperty(objIdx, "ExpectedType"));
+            variableLinks.Add(new StructProperty("SeqVarLink", camProps));
+            interpProps.AddOrReplaceProp(variableLinks);
+
+            // Add other properties
+            ArrayProperty<StrProperty> comment = new("m_aObjComment");
+            comment.Add(new StrProperty($"{(wantDir ? "Wheel Director" : "Wheel Camera")}"));
+            interpProps.AddOrReplaceProp(comment);
+            interpProps.AddOrReplaceProp(new BoolProperty(true, "bRewindOnPlay"));
+            interpProps.AddOrReplaceProp(new BoolProperty(true, "bClientSideOnly"));
+            interpProps.AddOrReplaceProp(new BoolProperty(true, "bLooping"));
+
+            interp.WriteProperties(interpProps);
+            interp.RemoveProperty("OutputLinks");
+
+            ExportEntry interpData = SequenceObjectCreator.CreateSequenceObject(sew.Pcc, "InterpData", cache);
+
+            // Add the objects to the sequence
+            KismetHelper.AddObjectToSequence(interp, sew.SelectedSequence);
+            KismetHelper.AddObjectToSequence(interpData, sew.SelectedSequence);
+            KismetHelper.CreateVariableLink(interp, "Data", interpData);
+
+            if (wantDir)
+            {
+                MatineeHelper.AddPreset("Director", interpData, sew.Pcc.Game);
+                ExportEntry camGroup = MatineeHelper.AddNewGroupToInterpData(interpData, camActor);
+                camGroup.WriteProperty(new NameProperty(camActor, "m_nmSFXFindActor"));
+            } else
+            {
+                MatineeHelper.AddPreset("Camera", interpData, sew.Pcc.Game, camActor);
+            }
+
+            MessageBox.Show($"Added dialogue wheel {(wantDir ? "director" : "camera")} template", "Success", MessageBoxButton.OK);
+        }
+
+        private static void ShowError(string errMsg)
+        {
+            MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
+        }
+
+        private static string promptForActor(string msg, string err)
+        {
+            if (PromptDialog.Prompt(null, msg) is string actor)
+            {
+                if (string.IsNullOrEmpty(actor))
+                {
+                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
+                    return null;
+                }
+                return actor;
+            }
+            return null;
+        }
+    }
+}

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
@@ -42,36 +42,29 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
 
             // We get a list of StructProperties instead of VarLinkInfo because we want to keep existing ones intact
             List<StructProperty> varLinks = interp.GetProperty<ArrayProperty<StructProperty>>("VariableLinks").ToList();
-            if (!inLoop) {
-                if (varLinks == null) {
-                    ShowError("The selected Interp contains no VariableLinks");
-                    return;
-                }
-            }
+			if (varLinks == null) {
+				ShowError("The selected Interp contains no VariableLinks");
+				return;
+			}
+            
 
             List<StructProperty> dataLinks = varLinks.Where(link => link.GetProp<StrProperty>("LinkDesc").Value == "Data").ToList();
-            if (!inLoop) {
-                if (!dataLinks.Any()) {
-                    ShowError("The selected Interp contains no Data variable link");
-                    return;
-                }
-            }
+			if (!dataLinks.Any()) {
+				ShowError("The selected Interp contains no Data variable link");
+				return;
+			}
 
             ObjectProperty dataObj = dataLinks.First().GetProp<ArrayProperty<ObjectProperty>>("LinkedVariables").FirstOrDefault();
-            if (!inLoop) {
-                if (dataObj == null) {
-                    ShowError("No InterpDatas were linked to the Data variable link");
-                    return;
-                }
-            }
+			if (dataObj == null) {
+				ShowError("No InterpDatas were linked to the Data variable link");
+				return;
+			}
 
             ExportEntry interpData = sew.Pcc.GetUExport(dataObj.Value);
-            if (!inLoop) {
-                if (interpData.ClassName != "InterpData") {
-                    ShowError("The first object linked to the Data variable link is not an InterpData");
-                    return;
-                }
-            }
+			if (interpData.ClassName != "InterpData") {
+				ShowError("The first object linked to the Data variable link is not an InterpData");
+				return;
+			}
 
             // Don't check if there are no InterpGroups, since an update could be to remove all of them
             ArrayProperty<ObjectProperty> interpGroups = interpData.GetProperty<ArrayProperty<ObjectProperty>>("InterpGroups");
@@ -84,7 +77,6 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
             groupNames.AddRange(interpGroups.Where(id => {
                 ExportEntry group = null;
                 if (!sew.Pcc.TryGetUExport(id.Value, out group)) { return false; }
-
                 return group.GetProperty<NameProperty>("GroupName") != null;
             }).Select(id => {
                 ExportEntry group = sew.Pcc.GetUExport(id.Value);
@@ -100,7 +92,7 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
                 }
                 else {
                     PropertyCollection props = GlobalUnrealObjectInfo.getDefaultStructValue(sew.Pcc.Game, "SeqVarLink", true);
-                    props.AddOrReplaceProp(new StrProperty(name, "LinKDesc"));
+                    props.AddOrReplaceProp(new StrProperty(name, "LinkDesc"));
                     int index = sew.Pcc.FindImport("Engine.SeqVar_Object").UIndex;
                     props.AddOrReplaceProp(new ObjectProperty(index, "ExpectedType"));
                     props.AddOrReplaceProp(new IntProperty(1, "MinVars"));
@@ -190,7 +182,7 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
             ArrayProperty<StructProperty> variableLinks = interp.GetProperty<ArrayProperty<StructProperty>>("VariableLinks");
             // Add camera varLink
             PropertyCollection camProps = GlobalUnrealObjectInfo.getDefaultStructValue(sew.Pcc.Game, "SeqVarLink", true);
-            camProps.AddOrReplaceProp(new StrProperty(camActor, "LinKDesc"));
+            camProps.AddOrReplaceProp(new StrProperty(camActor, "LinkDesc"));
             int objIdx = sew.Pcc.FindImport("Engine.SeqVar_Object").UIndex;
             camProps.AddOrReplaceProp(new ObjectProperty(objIdx, "ExpectedType"));
             variableLinks.Add(new StructProperty("SeqVarLink", camProps));

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
@@ -12,11 +12,13 @@ using System.Linq;
 using System.Windows;
 using static LegendaryExplorerCore.Kismet.SeqTools;
 
-namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
+namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
+{
     /// <summary>
     /// Experiments in Sequence Editor (Exkywor's stuff)
     /// </summary>
-    public static class SequenceEditorExperimentsE {
+    public static class SequenceEditorExperimentsE
+    {
         /// <summary>
         /// Updates the variable links of the selected Interp. Removes links that no longer have a matching InterpGroup,
         /// adds links for new groups, and keeps groups that remaing the same.
@@ -24,17 +26,21 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
         /// <param name="sew">Sequence Editor window.</param>
         /// <param name="inLoop">Whether we're updating in a loop. Used to avoid double-checking what the caller has already checked.</param>
         /// <param name="interp">Interp to update. Used to pass an interp gotten from a loop, rather than being a selected object.</param>
-        public static void UpdateVarLinks(SequenceEditorWPF sew, bool inLoop = false, ExportEntry interp = null) {
-            if (interp == null) {
+        public static void UpdateVarLinks(SequenceEditorWPF sew, bool inLoop = false, ExportEntry interp = null)
+        {
+            if (interp == null)
+            {
                 if (sew.Pcc == null || sew.SelectedItem == null || sew.SelectedItem.Entry == null) { return; }
 
-                if (!sew.SelectedObjects.HasExactly(1)) {
+                if (!sew.SelectedObjects.HasExactly(1))
+                {
                     ShowError("Select only one Interp object");
                     return;
                 }
 
                 interp = sew.SelectedObjects[0].Export;
-                if (interp.ClassName != "SeqAct_Interp") {
+                if (interp.ClassName != "SeqAct_Interp")
+                {
                     ShowError("Selected object is not a SeqAct_Interp");
                     return;
                 }
@@ -42,29 +48,33 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
 
             // We get a list of StructProperties instead of VarLinkInfo because we want to keep existing ones intact
             List<StructProperty> varLinks = interp.GetProperty<ArrayProperty<StructProperty>>("VariableLinks").ToList();
-			if (varLinks == null) {
-				ShowError("The selected Interp contains no VariableLinks");
-				return;
-			}
-            
+            if (varLinks == null)
+            {
+                ShowError("The selected Interp contains no VariableLinks");
+                return;
+            }
+
 
             List<StructProperty> dataLinks = varLinks.Where(link => link.GetProp<StrProperty>("LinkDesc").Value == "Data").ToList();
-			if (!dataLinks.Any()) {
-				ShowError("The selected Interp contains no Data variable link");
-				return;
-			}
+            if (!dataLinks.Any())
+            {
+                ShowError("The selected Interp contains no Data variable link");
+                return;
+            }
 
             ObjectProperty dataObj = dataLinks.First().GetProp<ArrayProperty<ObjectProperty>>("LinkedVariables").FirstOrDefault();
-			if (dataObj == null) {
-				ShowError("No InterpDatas were linked to the Data variable link");
-				return;
-			}
+            if (dataObj == null)
+            {
+                ShowError("No InterpDatas were linked to the Data variable link");
+                return;
+            }
 
             ExportEntry interpData = sew.Pcc.GetUExport(dataObj.Value);
-			if (interpData.ClassName != "InterpData") {
-				ShowError("The first object linked to the Data variable link is not an InterpData");
-				return;
-			}
+            if (interpData.ClassName != "InterpData")
+            {
+                ShowError("The first object linked to the Data variable link is not an InterpData");
+                return;
+            }
 
             // Don't check if there are no InterpGroups, since an update could be to remove all of them
             ArrayProperty<ObjectProperty> interpGroups = interpData.GetProperty<ArrayProperty<ObjectProperty>>("InterpGroups");
@@ -74,23 +84,28 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
             groupNames.Add("Data");
             groupNames.Add("Anchor");
 
-            groupNames.AddRange(interpGroups.Where(id => {
+            groupNames.AddRange(interpGroups.Where(id =>
+            {
                 ExportEntry group = null;
                 if (!sew.Pcc.TryGetUExport(id.Value, out group)) { return false; }
                 return group.GetProperty<NameProperty>("GroupName") != null;
-            }).Select(id => {
+            }).Select(id =>
+            {
                 ExportEntry group = sew.Pcc.GetUExport(id.Value);
                 return group.GetProperty<NameProperty>("GroupName").Value.Name;
             }).Distinct().ToList());
 
             List<StructProperty> updatedLinks = new();
-            foreach (string name in groupNames) {
+            foreach (string name in groupNames)
+            {
                 // Keep existing varLinks if they are the default Data or Anchor, or if it already exists in the list, and add new links.
                 StructProperty varLink = varLinks.Find(link => string.Equals(link.GetProp<StrProperty>("LinkDesc").Value, name, StringComparison.OrdinalIgnoreCase));
-                if (varLink != null) {
+                if (varLink != null)
+                {
                     updatedLinks.Add(varLink);
                 }
-                else {
+                else
+                {
                     PropertyCollection props = GlobalUnrealObjectInfo.getDefaultStructValue(sew.Pcc.Game, "SeqVarLink", true);
                     props.AddOrReplaceProp(new StrProperty(name, "LinkDesc"));
                     int index = sew.Pcc.FindImport("Engine.SeqVar_Object").UIndex;
@@ -106,36 +121,44 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
             updatedLinks.ForEach(link => variableLinksProp.Add(link));
             interp.WriteProperty(variableLinksProp);
 
-            if (!inLoop) {
+            if (!inLoop)
+            {
                 MessageBox.Show($"Variable links updated", "Success", MessageBoxButton.OK);
             }
         }
-        
+
         /// <summary>
         /// Updates the variable links of all selected interps, or all interps in the selected sequence, that contain an interpData.
         /// </summary>
         /// <param name="sew">Sequence Editor window.</param>
         /// <param name="selected">True to update only selected interps. Falls to update the whole sequence.</param>
-        public static void UpdateSequenceVarLinks(SequenceEditorWPF sew, bool selected = false) {
+        public static void UpdateSequenceVarLinks(SequenceEditorWPF sew, bool selected = false)
+        {
             if (sew.Pcc == null || sew.SelectedSequence == null) { return; }
 
             ExportEntry selectedSequence = null;
-            if (selected) {
+            if (selected)
+            {
                 if (sew.SelectedObjects.Count == 0) { return; }
-            } else {
+            }
+            else
+            {
                 selectedSequence = sew.Pcc.GetUExport(sew.SelectedSequence.UIndex);
-                if (selectedSequence.ClassName != "Sequence") {
+                if (selectedSequence.ClassName != "Sequence")
+                {
                     ShowError("Selected sequence is not a valid sequence.");
                     return;
-                 }
+                }
             }
 
             IEnumerable<ExportEntry> interps = selected ? sew.SelectedObjects.Select(el => el.Export)
                                                         : GetAllSequenceElements(selectedSequence).Select(el => (ExportEntry)el);
 
-            interps = interps.Where(export => {
+            interps = interps.Where(export =>
+            {
                 // Keep only Interps that contain valid InterpDatas
-                if (export.ClassName == "SeqAct_Interp") {
+                if (export.ClassName == "SeqAct_Interp")
+                {
                     List<StructProperty> varLinks = export.GetProperty<ArrayProperty<StructProperty>>("VariableLinks").ToList();
                     if (varLinks == null) { return false; }
                     List<StructProperty> dataLinks = varLinks.Where(link => link.GetProp<StrProperty>("LinkDesc").Value == "Data").ToList();
@@ -146,21 +169,24 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
                     if (interpData.ClassName != "InterpData") { return false; }
                     return true;
                 }
-                else {
+                else
+                {
                     return false;
                 }
             }).ToList();
 
-            if (!interps.Any()) {
+            if (!interps.Any())
+            {
                 ShowError($"Selected {(selected ? "interps contained no" : "sequence contains no interps with")} linked interpDatas.");
                 return;
             }
 
-            foreach (ExportEntry interp in interps) {
+            foreach (ExportEntry interp in interps)
+            {
                 UpdateVarLinks(sew, true, interp);
             }
 
-            MessageBox.Show($"All {(selected ? "selected " :"")}interps' variable links were updated", "Success", MessageBoxButton.OK);
+            MessageBox.Show($"All {(selected ? "selected " : "")}interps' variable links were updated", "Success", MessageBoxButton.OK);
         }
 
         /// <summary>
@@ -168,7 +194,8 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
         /// </summary>
         /// <param name="sew">Current SE instance.</param>
         /// <param name="wantDir">True to add director template, false for camera template.</param>
-        public static void AddDialogueWheelTemplate(SequenceEditorWPF sew, bool wantDir = false) {
+        public static void AddDialogueWheelTemplate(SequenceEditorWPF sew, bool wantDir = false)
+        {
             if (sew.Pcc == null || sew.SelectedSequence == null) { return; }
 
             string camActor = promptForActor($"Name of camera actor to {(wantDir ? "control" : "add")}:", "Not a valid camera actor name.");
@@ -209,25 +236,31 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments {
             KismetHelper.AddObjectToSequence(interpData, sew.SelectedSequence);
             KismetHelper.CreateVariableLink(interp, "Data", interpData);
 
-            if (wantDir) {
+            if (wantDir)
+            {
                 MatineeHelper.AddPreset("Director", interpData, sew.Pcc.Game);
                 ExportEntry camGroup = MatineeHelper.AddNewGroupToInterpData(interpData, camActor);
                 camGroup.WriteProperty(new NameProperty(camActor, "m_nmSFXFindActor"));
             }
-            else {
+            else
+            {
                 MatineeHelper.AddPreset("Camera", interpData, sew.Pcc.Game, camActor);
             }
 
             MessageBox.Show($"Added dialogue wheel {(wantDir ? "director" : "camera")} template", "Success", MessageBoxButton.OK);
         }
 
-        private static void ShowError(string errMsg) {
+        private static void ShowError(string errMsg)
+        {
             MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
         }
 
-        private static string promptForActor(string msg, string err) {
-            if (PromptDialog.Prompt(null, msg) is string actor) {
-                if (string.IsNullOrEmpty(actor)) {
+        private static string promptForActor(string msg, string err)
+        {
+            if (PromptDialog.Prompt(null, msg) is string actor)
+            {
+                if (string.IsNullOrEmpty(actor))
+                {
                     MessageBox.Show(err, "Warning", MessageBoxButton.OK);
                     return null;
                 }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml
@@ -170,6 +170,11 @@
                               ToolTip="Reads an input package and parses the information required for them to be viewed correctly in Sequence Editor. Only works for this session" />
                     <MenuItem Header="Commit object positions to objects" Click="CommitObjectPositions_Clicked"
                               ToolTip="Writes the node positions of all nodes to the properties for ObjPosX and ObjPosY" />
+					<MenuItem Header="Exkywor's buttons for lazy people">
+                        <MenuItem Header="Add Missing Variable Links" Click="AddMissingVarLinks_Clicked" ToolTip="Adds missing named groups from the linked InterpData to the variable links"/>
+                        <MenuItem Header="Add Dialogue Wheel Camera" Click="AddDialogueWheelCam_Clicked" ToolTip="Adds an Interp and an InterpData template to control a dialogue wheel camera"/>
+                        <MenuItem Header="Add Dialogue Wheel Director" Click="AddDialogueWheelDir_Clicked" ToolTip="Adds an Interp and an InterpData template to control the camera during a dialogue wheel"/>
+                    </MenuItem>
                 </MenuItem>
             </Menu>
             <StatusBar Height="23" DockPanel.Dock="Bottom">

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml
@@ -171,9 +171,8 @@
                     <MenuItem Header="Commit object positions to objects" Click="CommitObjectPositions_Clicked"
                               ToolTip="Writes the node positions of all nodes to the properties for ObjPosX and ObjPosY" />
 					<MenuItem Header="Exkywor's buttons for lazy people">
-                        <MenuItem Header="Update Interp's Variable Links" Click="UpdateVarLinks_Clicked" ToolTip="Adds missing named interpGroups, removes deleted ones, and keeps existing ones in the variable links."/>
                         <MenuItem Header="Update Selected Interps' Variable Links" Click="UpdateSelVarLinks_Clicked" ToolTip="Updated the variable links of the selected interps in the sequence."/>
-                        <MenuItem Header="Update Sequence's Interps' Variable Links" Click="UpdateSequenceVarLinks_Clicked" ToolTip="Updated the variable links of all interps in the selected sequence."/>
+                        <MenuItem Header="Update Sequence Interps' Variable Links" Click="UpdateSequenceVarLinks_Clicked" ToolTip="Updated the variable links of all interps in the selected sequence."/>
                         <MenuItem Header="Add Dialogue Wheel Camera" Click="AddDialogueWheelCam_Clicked" ToolTip="Adds an Interp and an InterpData template to control a dialogue wheel camera"/>
                         <MenuItem Header="Add Dialogue Wheel Director" Click="AddDialogueWheelDir_Clicked" ToolTip="Adds an Interp and an InterpData template to control the camera during a dialogue wheel"/>
                     </MenuItem>

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml
@@ -172,6 +172,8 @@
                               ToolTip="Writes the node positions of all nodes to the properties for ObjPosX and ObjPosY" />
 					<MenuItem Header="Exkywor's buttons for lazy people">
                         <MenuItem Header="Update Interp's Variable Links" Click="UpdateVarLinks_Clicked" ToolTip="Adds missing named interpGroups, removes deleted ones, and keeps existing ones in the variable links."/>
+                        <MenuItem Header="Update Selected Interps' Variable Links" Click="UpdateSelVarLinks_Clicked" ToolTip="Updated the variable links of the selected interps in the sequence."/>
+                        <MenuItem Header="Update Sequence's Interps' Variable Links" Click="UpdateSequenceVarLinks_Clicked" ToolTip="Updated the variable links of all interps in the selected sequence."/>
                         <MenuItem Header="Add Dialogue Wheel Camera" Click="AddDialogueWheelCam_Clicked" ToolTip="Adds an Interp and an InterpData template to control a dialogue wheel camera"/>
                         <MenuItem Header="Add Dialogue Wheel Director" Click="AddDialogueWheelDir_Clicked" ToolTip="Adds an Interp and an InterpData template to control the camera during a dialogue wheel"/>
                     </MenuItem>

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml
@@ -171,7 +171,7 @@
                     <MenuItem Header="Commit object positions to objects" Click="CommitObjectPositions_Clicked"
                               ToolTip="Writes the node positions of all nodes to the properties for ObjPosX and ObjPosY" />
 					<MenuItem Header="Exkywor's buttons for lazy people">
-                        <MenuItem Header="Add Missing Variable Links" Click="AddMissingVarLinks_Clicked" ToolTip="Adds missing named groups from the linked InterpData to the variable links"/>
+                        <MenuItem Header="Update Interp's Variable Links" Click="UpdateVarLinks_Clicked" ToolTip="Adds missing named interpGroups, removes deleted ones, and keeps existing ones in the variable links."/>
                         <MenuItem Header="Add Dialogue Wheel Camera" Click="AddDialogueWheelCam_Clicked" ToolTip="Adds an Interp and an InterpData template to control a dialogue wheel camera"/>
                         <MenuItem Header="Add Dialogue Wheel Director" Click="AddDialogueWheelDir_Clicked" ToolTip="Adds an Interp and an InterpData template to control the camera during a dialogue wheel"/>
                     </MenuItem>

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
@@ -2681,6 +2681,23 @@ namespace LegendaryExplorer.Tools.Sequence_Editor
             SequenceEditorExperimentsM.CommitSequenceObjectPositions(this);
         }
 
+        private void AddMissingVarLinks_Clicked(object sender, RoutedEventArgs e) {
+            SequenceEditorExperimentsE.AddMissingVarLinks(GetSEWindow());
+        }
+
+        private void AddDialogueWheelCam_Clicked(object sender, RoutedEventArgs e) {
+            SequenceEditorExperimentsE.AddDialogueWheelTemplate(GetSEWindow());
+        }
+
+        private void AddDialogueWheelDir_Clicked(object sender, RoutedEventArgs e) {
+            SequenceEditorExperimentsE.AddDialogueWheelTemplate(GetSEWindow(), true);
+        }
+
+        public SequenceEditorWPF GetSEWindow() {
+            if (GetWindow(this) is SequenceEditorWPF sew) { return sew; }
+            return null;
+        }
+
         public string Toolname => "SequenceEditor";
     }
     static class SequenceEditorExtensions

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
@@ -2681,8 +2681,8 @@ namespace LegendaryExplorer.Tools.Sequence_Editor
             SequenceEditorExperimentsM.CommitSequenceObjectPositions(this);
         }
 
-        private void AddMissingVarLinks_Clicked(object sender, RoutedEventArgs e) {
-            SequenceEditorExperimentsE.AddMissingVarLinks(GetSEWindow());
+        private void UpdateVarLinks_Clicked(object sender, RoutedEventArgs e) {
+            SequenceEditorExperimentsE.UpdateVarLinks(GetSEWindow());
         }
 
         private void AddDialogueWheelCam_Clicked(object sender, RoutedEventArgs e) {

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
@@ -2681,10 +2681,6 @@ namespace LegendaryExplorer.Tools.Sequence_Editor
             SequenceEditorExperimentsM.CommitSequenceObjectPositions(this);
         }
 
-        private void UpdateVarLinks_Clicked(object sender, RoutedEventArgs e) {
-            SequenceEditorExperimentsE.UpdateVarLinks(GetSEWindow());
-        }
-
         private void UpdateSelVarLinks_Clicked(object sender, RoutedEventArgs e) {
             SequenceEditorExperimentsE.UpdateSequenceVarLinks(GetSEWindow(), true);
         }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
@@ -1,22 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
-using Color = System.Drawing.Color;
-using OpenFileDialog = Microsoft.Win32.OpenFileDialog;
-using SaveFileDialog = Microsoft.Win32.SaveFileDialog;
-using System.Windows.Threading;
-using Gammtek.Conduit.MassEffect3.SFXGame.StateEventMap;
+﻿using Gammtek.Conduit.MassEffect3.SFXGame.StateEventMap;
 using LegendaryExplorer.Dialogs;
 using LegendaryExplorer.Misc;
 using LegendaryExplorer.Misc.AppSettings;
@@ -31,19 +13,37 @@ using LegendaryExplorer.Tools.SequenceObjects;
 using LegendaryExplorer.UserControls.SharedToolControls;
 using LegendaryExplorerCore.GameFilesystem;
 using LegendaryExplorerCore.Gammtek.Extensions.Collections.Generic;
+using LegendaryExplorerCore.Helpers;
+using LegendaryExplorerCore.Kismet;
+using LegendaryExplorerCore.Misc;
 using LegendaryExplorerCore.Packages;
 using LegendaryExplorerCore.Packages.CloningImportingAndRelinking;
 using LegendaryExplorerCore.Unreal;
 using LegendaryExplorerCore.Unreal.BinaryConverters;
-using Microsoft.WindowsAPICodePack.Dialogs;
-using Image = System.Drawing.Image;
-using LegendaryExplorerCore.Helpers;
-using LegendaryExplorerCore.Kismet;
-using LegendaryExplorerCore.Misc;
 using LegendaryExplorerCore.Unreal.ObjectInfo;
+using Microsoft.WindowsAPICodePack.Dialogs;
+using Newtonsoft.Json;
 using Piccolo;
 using Piccolo.Event;
 using Piccolo.Nodes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using Color = System.Drawing.Color;
+using Image = System.Drawing.Image;
+using OpenFileDialog = Microsoft.Win32.OpenFileDialog;
+using SaveFileDialog = Microsoft.Win32.SaveFileDialog;
 
 namespace LegendaryExplorer.Tools.Sequence_Editor
 {
@@ -2681,23 +2681,28 @@ namespace LegendaryExplorer.Tools.Sequence_Editor
             SequenceEditorExperimentsM.CommitSequenceObjectPositions(this);
         }
 
-        private void UpdateSelVarLinks_Clicked(object sender, RoutedEventArgs e) {
+        private void UpdateSelVarLinks_Clicked(object sender, RoutedEventArgs e)
+        {
             SequenceEditorExperimentsE.UpdateSequenceVarLinks(GetSEWindow(), true);
         }
 
-        private void UpdateSequenceVarLinks_Clicked(object sender, RoutedEventArgs e) {
+        private void UpdateSequenceVarLinks_Clicked(object sender, RoutedEventArgs e)
+        {
             SequenceEditorExperimentsE.UpdateSequenceVarLinks(GetSEWindow());
         }
 
-        private void AddDialogueWheelCam_Clicked(object sender, RoutedEventArgs e) {
+        private void AddDialogueWheelCam_Clicked(object sender, RoutedEventArgs e)
+        {
             SequenceEditorExperimentsE.AddDialogueWheelTemplate(GetSEWindow());
         }
 
-        private void AddDialogueWheelDir_Clicked(object sender, RoutedEventArgs e) {
+        private void AddDialogueWheelDir_Clicked(object sender, RoutedEventArgs e)
+        {
             SequenceEditorExperimentsE.AddDialogueWheelTemplate(GetSEWindow(), true);
         }
 
-        public SequenceEditorWPF GetSEWindow() {
+        public SequenceEditorWPF GetSEWindow()
+        {
             if (GetWindow(this) is SequenceEditorWPF sew) { return sew; }
             return null;
         }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/SequenceEditorWPF.xaml.cs
@@ -2685,6 +2685,14 @@ namespace LegendaryExplorer.Tools.Sequence_Editor
             SequenceEditorExperimentsE.UpdateVarLinks(GetSEWindow());
         }
 
+        private void UpdateSelVarLinks_Clicked(object sender, RoutedEventArgs e) {
+            SequenceEditorExperimentsE.UpdateSequenceVarLinks(GetSEWindow(), true);
+        }
+
+        private void UpdateSequenceVarLinks_Clicked(object sender, RoutedEventArgs e) {
+            SequenceEditorExperimentsE.UpdateSequenceVarLinks(GetSEWindow());
+        }
+
         private void AddDialogueWheelCam_Clicked(object sender, RoutedEventArgs e) {
             SequenceEditorExperimentsE.AddDialogueWheelTemplate(GetSEWindow());
         }


### PR DESCRIPTION
Adds the following experiments:
- Add director and camera Interp templates for controlling the dialogue wheel.
- Update missing variable links of selected or all Interps in the selected sequence. It adds any new named InterpGroup to the links, removes any link that no longer matches an InterpGroup of the InterpData, and keeps anyone that hasn't been touched. It does not change the Data or Anchor links, as those are added by default.