### PR TITLE
PackageEd: Refactor Baldinator to MorphMaleHair and add Rollinator experiment

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -164,6 +164,7 @@
         <MenuItem Header="Batch Add/Modify Materials' Parameters" Click="BatchPatchMaterialsParameters_Click" ToolTip="Batch add/modify a list of vector or scalar parameters in a list of given materials to all files in a given DLC folder."/>
         <MenuItem Header="Batch Set Bool Property Value" Click="BatchSetBoolPropVal_Click" ToolTip="Batch set the value of a boolean property to all given classes in a given DLC folder."/>
         <MenuItem Header="The Baldinator" Click="Baldinator_Click" ToolTip="Modify the hair morph targets of a male headmorph to make it bald."/>
+        <MenuItem Header="The Rollinator" Click="Rollinator_Click" ToolTip="Modify the hair morph targets of a male headmorph to make it rollins."/>
         <MenuItem Header="Copy Property" Click="CopyProperty_Click" ToolTip="Copy the selected property to another export of the same class."/>
         <MenuItem Header="Copy Material to BioMaterialOverrides or MaterialInstanceConstants" Click="CopyMatToBMOorMIC_Click" ToolTip="Copies the texture, vector, and scalar properties of a BioMaterialOverride into [Bio]MaterialInstanceConstants, or vice-versa."/>
         <MenuItem Header="Remove References to SkeletalMesh or StaticMesh in Distance" Click="SMRefRemover_Click" ToolTip="Removes SMC references to a SkeletalMesh or StaticMesh within a given distance"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
@@ -1370,6 +1370,11 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
             PackageEditorExperimentsO.Baldinator(GetPEWindow());
         }
 
+        private void Rollinator_Click(object sender, RoutedEventArgs a)
+        {
+            PackageEditorExperimentsO.Rollinator(GetPEWindow());
+        }
+
         private void CopyProperty_Click(object sender, RoutedEventArgs e)
         {
             PackageEditorExperimentsO.CopyProperty(GetPEWindow());


### PR DESCRIPTION
This experiment abstracts the code behind The Baldinator experiment into a separate function so it can be reused for other settings, like in the newly added Rollinator option.
In the future, if more configurations are needed, I may add an option to provide the parameters rather than rely on predefined settings.