### PR TITLE
PackageEditor: Improve Batch Bool exp to prompt for adding bools if missing.

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -528,6 +528,10 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                     return;
                 }
 
+                bool addBool = MessageBoxResult.Yes == MessageBox.Show(
+                        "Add boolean property if an object does not not have it?",
+                        "Add bool", MessageBoxButton.YesNo);
+
                 // Get the state to set the booleans to
                 string stateString = InputComboBoxDialog.GetValue(null, "State to set the bools to", "Bool state",
                     new[] { "True", "False" }, "True");
@@ -543,8 +547,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                     foreach (ExportEntry export in exports)
                     {
                         BoolProperty currProp = export.GetProperty<BoolProperty>(boolName);
-                        if (currProp == null) { continue; }
-                        export.RemoveProperty(boolName);
+                        if ((currProp == null) && !addBool) { continue; }
                         export.WriteProperty(new BoolProperty(state, boolName));
                     }
                     pcc.Save();


### PR DESCRIPTION
This tweak adds a prompt for the batch set bool experiment to ask if the user wants the boolean to be added if it's found missing. In practice, this allows you to batch add bools to all instances of a class in all the pccs in a folder.