### PR TITLE
Experiments to clean conversations

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1140,7 +1140,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
                     NameProperty name = group.GetProperty<NameProperty>("GroupName");
 
-                    if (name != null && !string.IsNullOrEmpty(name.Value.Instanced) && name.Value.Instanced == "Conversation")
+                    if (name != null && !string.IsNullOrEmpty(name.Value.Instanced) && name.Value.Instanced.Equals("Conversation", StringComparison.OrdinalIgnoreCase))
                     {
                         filteredGroupsRefs.Add(groupRef);
                     }
@@ -1277,7 +1277,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 IEnumerable<KeyValuePair<uint, string>> updatedBanks = wwiseBank.ReferencedBanks
                     .Select(referencedBank =>
                     {
-                        if (referencedBank.Value == oldName) { return new(newBankID, newName); }
+                        if (referencedBank.Value.Equals(oldName, StringComparison.OrdinalIgnoreCase)) { return new(newBankID, newName); }
                         else { return referencedBank; }
                     });
                 wwiseBank.ReferencedBanks = new OrderedMultiValueDictionary<uint, string>(updatedBanks);

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1811,7 +1811,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 else
                 {
                     // Most likely a NonSpkr, in which case we'll use the full name
-                    if (oldFxaFullName.Length > 8 && oldFxaFullName[^8..].ToLower() is "_nonspkr")
+                    if (oldFxaFullName.EndsWith("_nonspkr", StringComparison.OrdinalIgnoreCase))
                     {
                         oldFxaName = oldFxaFullName;
                     }
@@ -1822,11 +1822,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
                 FaceFXAnimSet faceFXAnimSet = fxaExport.GetBinaryData<FaceFXAnimSet>();
                 // Replace the old name in the name chunk
-                List<string> names = faceFXAnimSet.Names.Select(name =>
-                {
-                    if (name == oldFxaName) { return newFxaName; }
-                    else { return name; }
-                }).ToList();
+                List<string> names = faceFXAnimSet.Names.Select(name => name == oldFxaName ? newFxaName : name).ToList();
                 faceFXAnimSet.Names = names;
 
                 // Set the paths with the new names and update the names of WwiseStreams

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1605,7 +1605,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         /// <returns>The decimal representation of the hash.</returns>
         private static uint GetBankId(string name)
         {
-            byte[] bytedName = Encoding.ASCII.GetBytes(name);
+            byte[] bytedName = Encoding.ASCII.GetBytes(name.ToLower()); // Wwise automatically lowecases the input
 
             // FNV132 hashing algorithm
             uint hash = 2166136261;

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1127,6 +1127,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             foreach (ExportEntry interpData in interpDatas)
             {
                 ArrayProperty<ObjectProperty> interpGroupsRefs = interpData.GetProperty<ArrayProperty<ObjectProperty>>("InterpGroups");
+                if (interpGroupsRefs == null) { continue; }
                 List<ObjectProperty> filteredGroupsRefs = new();
 
                 // Save "Conversation" InterpGroup, trash the rest
@@ -1156,6 +1157,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                     ExportEntry interpGroup = pew.Pcc.GetUExport(interpGroupRef.Value);
 
                     ArrayProperty<ObjectProperty> interpTracksRefs = interpGroup.GetProperty<ArrayProperty<ObjectProperty>>("InterpTracks");
+                    if (interpTracksRefs == null) { continue; }
                     List<ObjectProperty> filteredTracksRefs = new();
 
                     foreach (ObjectProperty trackRef in interpTracksRefs)
@@ -1335,9 +1337,13 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
             // STEP 5: FXA, VO, AND OTHER NAME REPLACEMENTS ---------------------------------------------------------
 
-            List<ObjectProperty> fxas = bioConversation.GetProperty<ArrayProperty<ObjectProperty>>("m_aMaleFaceSets").ToList();
-            fxas.AddRange(bioConversation.GetProperty<ArrayProperty<ObjectProperty>>("m_aFemaleFaceSets"));
-            fxas.Add(bioConversation.GetProperty<ObjectProperty>("m_pNonSpeakerFaceFXSet"));
+            List<ObjectProperty> fxas = new();
+            ArrayProperty<ObjectProperty> maleFXAs = bioConversation.GetProperty<ArrayProperty<ObjectProperty>>("m_aMaleFaceSets");
+            if (maleFXAs != null) { fxas.AddRange(maleFXAs); }
+            ArrayProperty<ObjectProperty> femaleFXAs = bioConversation.GetProperty<ArrayProperty<ObjectProperty>>("m_aFemaleFaceSets");
+            if (femaleFXAs != null) { fxas.AddRange(femaleFXAs); }
+            ObjectProperty nonSpkrFxa = bioConversation.GetProperty<ObjectProperty>("m_pNonSpeakerFaceFXSet");
+            if (nonSpkrFxa != null) { fxas.Add(nonSpkrFxa); }
 
             foreach (ObjectProperty fxa in fxas)
             {
@@ -1379,6 +1385,8 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 {
                     foreach (FaceFXLine line in faceFXAnimSet.Lines)
                     {
+                        if (eventRefs[line.Index].Value == 0) { continue; }
+
                         // Update the path
                         ExportEntry wwiseEvent = pew.Pcc.GetUExport(eventRefs[line.Index].Value);
                         if (wwiseEvent != null)

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1464,7 +1464,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                             // Add to filteredOutboundLinks the elements of this outbound link that connect to a valid class
                             filteredOutboundLinks.Add(outboundLink
                                 .Where(link =>
-                                    link != null || validClasses.Contains(link.LinkedOp.ClassName, StringComparer.OrdinalIgnoreCase)
+                                    link == null || validClasses.Contains(link.LinkedOp.ClassName, StringComparer.OrdinalIgnoreCase)
                                 ).ToList());
                         }
                         SeqTools.WriteOutboundLinksToNode(seqObj, filteredOutboundLinks);

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1974,19 +1974,20 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         /// <returns>Union of input strings.</returns>
         private static string GetCommonPrefix(string s1, string s2)
         {
-            string union = "";
-            for (int w = 0, b = 0; w < s1.Length && b < s2.Length; w++, b++)
+            if (s1.Length == 0 || s2.Length == 0 || char.ToLower(s1[0]) != char.ToLower(s2[0]))
             {
-                if (char.ToLower(s1[w]) == char.ToLower(s2[b]))
+                return "";
+            }
+
+            for (int i = 1; i < s1.Length && i < s2.Length; i++)
+            {
+                if (char.ToLower(s1[i]) != char.ToLower(s2[i]))
                 {
-                    union += char.ToLower(s1[w]);
-                }
-                else
-                {
-                    break;
+                    return s1[..i];
                 }
             }
-            return union;
+
+            return s1.Length < s2.Length ? s1 : s2;
         }
 
         /// <summary>

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -312,11 +312,6 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             return null;
         }
 
-        private static void ShowError(string errMsg)
-        {
-            MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
-        }
-
         /// <summary>
         /// Batch patch parameters in a list of materials
         /// </summary>
@@ -1055,7 +1050,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            string newName = PromptDialog.Prompt(null, "New conversation name:");
+            string newName = PromptDialog.Prompt(null, "New conversation name:", "New name");
             // Check that the new name is not empty, no longe than 255, and doesn't contain white-spaces or symbols aside from _ or -
             if (string.IsNullOrEmpty(newName) || newName.Length > 240 || newName.Any(c => char.IsWhiteSpace(c) || (!(c is '_' or '-') && !char.IsLetterOrDigit(c))))
             {
@@ -1063,21 +1058,21 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            int newConvResRefID = promptForInt("New ConvResRefID:", "Not a valid ref id. It must be positive integer", 1);
+            int newConvResRefID = promptForInt("New ConvResRefID:", "Not a valid ref id. It must be positive integer", 1, "New ConvResRefID");
             if (newConvResRefID == -1) { return; }
 
-            int convNodeIDBase = promptForInt("New ConvNodeID base range:", "Not a valid base. It must be positive integer", 1);
+            int convNodeIDBase = promptForInt("New ConvNodeID base range:", "Not a valid base. It must be positive integer", 1, "New NodeID range");
             if (convNodeIDBase == -1) { return; }
 
             bool setNewWwiseBankID = MessageBoxResult.Yes == MessageBox.Show(
                 "Change the WwiseBank ID?\nIn general it's safe and better to do so, but there may be edge cases" +
                 "where doing so may overwrite parts of the WwiseBank binary that are not the ID.",
-                null, MessageBoxButton.YesNo);
+                "Set new bank ID", MessageBoxButton.YesNo);
 
             bool bringTrash = MessageBoxResult.No == MessageBox.Show(
                 "Discard sequence objects that are not Interp, InterpData, ConvNode or EndConvNode but link to them?\n" +
                 "In general it's better to discard them, but there may be edge cases where you may want to preseve them.",
-                null, MessageBoxButton.YesNo);
+                "Discard unneeded objects", MessageBoxButton.YesNo);
 
             ExportEntry bioConversation = (ExportEntry)pew.SelectedItem.Entry;
 
@@ -1574,16 +1569,22 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             return new StructProperty("Guid", props, "ExpressionGUID", true);
         }
 
+        private static void ShowError(string errMsg)
+        {
+            MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
+        }
+
         /// <summary>
         /// Prompts the user for an int, verifying that the int is valid.
         /// </summary>
         /// <param name="msg">Message to display for the prompt.</param>
         /// <param name="err">Error message to display.</param>
         /// <param name="biggerThan">Number the input must be bigger than. If not provided -2,147,483,648 will be used.</param>
+        /// <param name="title">Title for the prompt.</param>
         /// <returns>The input int.</returns>
-        private static int promptForInt(string msg, string err, int biggerThan = -2147483648)
+        private static int promptForInt(string msg, string err, int biggerThan = -2147483648, string title = "")
         {
-            if (PromptDialog.Prompt(null, msg) is string stringPrompt)
+            if (PromptDialog.Prompt(null, msg, title) is string stringPrompt)
             {
                 int intPrompt;
                 if (string.IsNullOrEmpty(stringPrompt) || !int.TryParse(stringPrompt, out intPrompt) || !(intPrompt > biggerThan))

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1344,7 +1344,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
                     NameProperty name = group.GetProperty<NameProperty>("GroupName");
 
-                    if (name != null && !string.IsNullOrEmpty(name.Value.Instanced) && name.Value.Instanced.Equals("Conversation", StringComparison.OrdinalIgnoreCase))
+                    if (name != null && !string.IsNullOrEmpty(name.Value) && name.Value.Name.Equals("Conversation", StringComparison.OrdinalIgnoreCase))
                     {
                         filteredGroupsRefs.Add(groupRef);
                     }
@@ -1568,7 +1568,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 conversation.LoadConversation(TLKManagerWPF.GlobalFindStrRefbyID, true);
             }
 
-            string oldBioConversationName = bioConversation.ObjectName.Instanced;
+            string oldBioConversationName = bioConversation.ObjectName;
             string oldName = "";
 
             // Get the old name found in all pieces of the conversation by getting the union of the bioconversation
@@ -1593,7 +1593,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             }
             else
             {
-                string oldWwiseBankName = conversation.WwiseBank.ObjectName.Instanced;
+                string oldWwiseBankName = conversation.WwiseBank.ObjectName;
                 oldName = GetUnionOfStrings(oldWwiseBankName, oldBioConversationName);
                 string newWwiseBankName = oldWwiseBankName.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
 
@@ -1611,7 +1611,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 ExportEntry link = pew.Pcc.GetUExport(bioConversation.idxLink);
                 if (link.ClassName == "Package")
                 {
-                    link.ObjectName = link.ObjectName.Instanced.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    link.ObjectName = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
                 }
             }
             // Replace name of the sound, sequence, and FXA package, which is separate in ME1
@@ -1620,7 +1620,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 ExportEntry link = pew.Pcc.GetUExport(conversation.Sequence.idxLink);
                 if (link.ClassName == "Package")
                 {
-                    link.ObjectName = link.ObjectName.Instanced.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    link.ObjectName = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
                 }
             }
             // Replace name of the sounds package, which is separate in ME2
@@ -1629,9 +1629,8 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 ExportEntry link = pew.Pcc.GetUExport(conversation.WwiseBank.idxLink);
                 if (link.ClassName == "Package")
                 {
-                    link.ObjectName = link.ObjectName.Instanced.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    link.ObjectName = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
                 }
-
             }
 
             // Must be called after everything else has been renamed due to the need ot update FXA paths.
@@ -1826,7 +1825,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
                 ExportEntry fxaExport = pew.Pcc.GetUExport(fxa.Value);
 
-                string oldFxaFullName = fxaExport.ObjectName.Instanced; // May contain _M, _F, or _NonSpkr
+                string oldFxaFullName = fxaExport.ObjectName; // May contain _M, _F, or _NonSpkr
                 string oldFxaName = oldFxaFullName; // Full name minus _M/_F, or including _NonSpkr
 
                 if (oldFxaFullName[^2..].ToLower() is "_m" or "_f")
@@ -1893,10 +1892,10 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                                     ExportEntry stream = pew.Pcc.GetUExport(streamRef.Value);
                                     if (stream == null) { continue; }
 
-                                    stream.ObjectName = stream.ObjectName.Instanced.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                                    stream.ObjectName = stream.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
                                     NameProperty bankName = stream.GetProperty<NameProperty>("BankName");
                                     if (bankName == null) { continue; }
-                                    bankName.Value = bankName.Value.Instanced.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                                    bankName.Value = bankName.Value.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
                                     stream.WriteProperty(bankName);
                                 }
                             }
@@ -1912,7 +1911,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
                                         ExportEntry wwiseStream = pew.Pcc.GetUExport(stream);
 
-                                        wwiseStream.ObjectName = wwiseStream.ObjectName.Instanced.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                                        wwiseStream.ObjectName = wwiseStream.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
 
                                         // This is similar to the step for LE2, but the general way of getting to it is more similar
                                         // to the LE3/ME3 way
@@ -1920,7 +1919,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                                         {
                                             NameProperty bankName = wwiseStream.GetProperty<NameProperty>("BankName");
                                             if (bankName == null) { continue; }
-                                            bankName.Value = bankName.Value.Instanced.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                                            bankName.Value = bankName.Value.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
                                             wwiseStream.WriteProperty(bankName);
                                         }
                                     }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1241,17 +1241,20 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                     {
                         IEnumerable<StructProperty> varLinks = seqObj.GetProperty<ArrayProperty<StructProperty>>("VariableLinks");
 
-                        List<StructProperty> newVarLinks = new();
+                        if (varLinks != null)
+                        {
+                            List<StructProperty> newVarLinks = new();
 
-                        StructProperty dataLink = varLinks.FirstOrDefault(link =>
-                            string.Equals(link.GetProp<StrProperty>("LinkDesc").Value, "Data", StringComparison.OrdinalIgnoreCase));
+                            StructProperty dataLink = varLinks.FirstOrDefault(link =>
+                                string.Equals(link.GetProp<StrProperty>("LinkDesc").Value, "Data", StringComparison.OrdinalIgnoreCase));
 
-                        if (dataLink != null) { newVarLinks.Add(dataLink); }
+                            if (dataLink != null) { newVarLinks.Add(dataLink); }
 
-                        newVarLinks.Add(CreateVarLink(pcc, "Anchor"));
-                        newVarLinks.Add(CreateVarLink(pcc, "Conversation"));
+                            newVarLinks.Add(CreateVarLink(pcc, "Anchor"));
+                            newVarLinks.Add(CreateVarLink(pcc, "Conversation"));
 
-                        seqObj.WriteProperty(new ArrayProperty<StructProperty>(newVarLinks, "VariableLinks"));
+                            seqObj.WriteProperty(new ArrayProperty<StructProperty>(newVarLinks, "VariableLinks"));
+                        }
                     }
 
                     filteredObjRefs.Add(objRef);
@@ -1757,10 +1760,10 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             // Update references to the old hash at the end of HIRC objects when they are found.
             // This is mostly safe, since we know the reference appears at the end of the unparsed data,
             // and we only replace it there.
+            byte[] oldID = BitConverter.GetBytes(oldBankID);
+            byte[] newID = BitConverter.GetBytes(newBankID);
             foreach (WwiseBank.HIRCObject hirc in wwiseBank.HIRCObjects.Values())
             {
-                byte[] oldID = BitConverter.GetBytes(oldBankID);
-                byte[] newID = BitConverter.GetBytes(newBankID);
                 if (hirc.unparsed != null && hirc.unparsed.Length >= 4) // Only replace if not null and at least width of hash
                 {
 

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -167,6 +167,7 @@
         <MenuItem Header="Copy Property" Click="CopyProperty_Click" ToolTip="Copy the selected property to another export of the same class."/>
         <MenuItem Header="Copy Material to BioMaterialOverrides or MaterialInstanceConstants" Click="CopyMatToBMOorMIC_Click" ToolTip="Copies the texture, vector, and scalar properties of a BioMaterialOverride into [Bio]MaterialInstanceConstants, or vice-versa."/>
         <MenuItem Header="Remove References to SkeletalMesh or StaticMesh in Distance" Click="SMRefRemover_Click" ToolTip="Removes SMC references to a SkeletalMesh or StaticMesh within a given distance"/>
+        <MenuItem Header="Clean BioConversation for Audio Donation" Click="CleanConvoDonor_Click" ToolTip="Keeps the BioEvtSysTrackVOElements only of all InterpDatas associated with the conversation, as well as performing other safety measures on it for audio donation."/>
     </MenuItem>
     <MenuItem Header="Object Database">
         <MenuItem Header="Build ME1 Object Database" Click="ChonkyDB_BuildME1GameDB"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -168,6 +168,12 @@
         <MenuItem Header="Copy Material to BioMaterialOverrides or MaterialInstanceConstants" Click="CopyMatToBMOorMIC_Click" ToolTip="Copies the texture, vector, and scalar properties of a BioMaterialOverride into [Bio]MaterialInstanceConstants, or vice-versa."/>
         <MenuItem Header="Remove References to SkeletalMesh or StaticMesh in Distance" Click="SMRefRemover_Click" ToolTip="Removes SMC references to a SkeletalMesh or StaticMesh within a given distance"/>
         <MenuItem Header="Clean BioConversation for Cloning" Click="CleanConvoDonor_Click" ToolTip="Rename a BioConversation, change its ID, rename all the FXAs and audio elements, and keep only VOTracks, Conversation InterpGroups and conversation objects."/>
+        <MenuItem Header="Clean Sequence" Click="CleanSequence_Click" ToolTip="Cleans a sequence of objects that are not ConvNode, Interp, InterpData, and ConvNodeEnd; and optionally, of non-Conversation InterpGroups and non-VOElements InterpTracks."/>
+        <MenuItem Header="Clean Sequence's InterpDatas" Click="CleanSequenceInterpDatas_Click" ToolTip="Clean a sequence of non-Conversation InterpGroups and non-VOElements InterpTracks."/>
+        <MenuItem Header="Change Conversation ID and ConvNodes' ID" Click="ChangeConvoIDandConvNodeIDs_Click" ToolTip="Change a conversation's ConvResRefID and give its ConvNodes a new ID range."/>
+        <MenuItem Header="Rename Conversation" Click="RenameConversation_Click" ToolTip="Rename a conversation, changing the WwiseBank name and FXAs and related elements too, and optionally, updating its WwiseBank ID."/>
+        <MenuItem Header="Rename WwiseBank" Click="RenameWwiseBank_Click" ToolTip="Rename a WwiseBank, and optionally udate its ID."/>
+        <MenuItem Header="Update WwiseBank's ID" Click="UpdateWwiseBankID_Click" ToolTip="Udate a WwiseBank's ID."/>
     </MenuItem>
     <MenuItem Header="Object Database">
         <MenuItem Header="Build ME1 Object Database" Click="ChonkyDB_BuildME1GameDB"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -167,7 +167,7 @@
         <MenuItem Header="Copy Property" Click="CopyProperty_Click" ToolTip="Copy the selected property to another export of the same class."/>
         <MenuItem Header="Copy Material to BioMaterialOverrides or MaterialInstanceConstants" Click="CopyMatToBMOorMIC_Click" ToolTip="Copies the texture, vector, and scalar properties of a BioMaterialOverride into [Bio]MaterialInstanceConstants, or vice-versa."/>
         <MenuItem Header="Remove References to SkeletalMesh or StaticMesh in Distance" Click="SMRefRemover_Click" ToolTip="Removes SMC references to a SkeletalMesh or StaticMesh within a given distance"/>
-        <MenuItem Header="Clean BioConversation for Audio Donation" Click="CleanConvoDonor_Click" ToolTip="Keeps the BioEvtSysTrackVOElements only of all InterpDatas associated with the conversation, as well as performing other safety measures on it for audio donation."/>
+        <MenuItem Header="Clean BioConversation for Cloning" Click="CleanConvoDonor_Click" ToolTip="Rename a BioConversation, change its ID, rename all the FXAs and audio elements, and keep only VOTracks, Conversation InterpGroups and conversation objects."/>
     </MenuItem>
     <MenuItem Header="Object Database">
         <MenuItem Header="Build ME1 Object Database" Click="ChonkyDB_BuildME1GameDB"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
@@ -211,7 +211,7 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
                 Application.Current.Dispatcher.InvokeAsync(() => { pew.BusyText = $"Building UDK Object Info [{done}/{total}]"; });
             }
 
-            Task.Run(() => 
+            Task.Run(() =>
             {
                 UDKUnrealObjectInfo.generateInfo(Path.Combine(AppDirectories.ExecFolder, "UDKObjectInfo.json"), true, setProgress);
             }).ContinueWithOnUIThread(x =>
@@ -1388,6 +1388,36 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
         private void CleanConvoDonor_Click(object sender, RoutedEventArgs e)
         {
             PackageEditorExperimentsO.CleanConvoDonor(GetPEWindow());
+        }
+
+        private void CleanSequence_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.CleanSequence(false, GetPEWindow());
+        }
+
+        private void CleanSequenceInterpDatas_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.CleanSequenceInterpDatas(false, GetPEWindow());
+        }
+
+        private void ChangeConvoIDandConvNodeIDs_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.ChangeConvoIDandConvNodeIDs(false, GetPEWindow());
+        }
+
+        private void RenameConversation_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.RenameConversation(false, GetPEWindow());
+        }
+
+        private void RenameWwiseBank_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.RenameWwiseBank(false, GetPEWindow());
+        }
+
+        private void UpdateWwiseBankID_Click (object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.UpdateWwiseBankID(false, GetPEWindow());
         }
         #endregion
 

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
@@ -1392,32 +1392,32 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
 
         private void CleanSequence_Click(object sender, RoutedEventArgs e)
         {
-            PackageEditorExperimentsO.CleanSequence(false, GetPEWindow());
+            PackageEditorExperimentsO.CleanSequenceExperiment(GetPEWindow());
         }
 
         private void CleanSequenceInterpDatas_Click(object sender, RoutedEventArgs e)
         {
-            PackageEditorExperimentsO.CleanSequenceInterpDatas(false, GetPEWindow());
+            PackageEditorExperimentsO.CleanSequenceInterpDatasExperiment(GetPEWindow());
         }
 
         private void ChangeConvoIDandConvNodeIDs_Click(object sender, RoutedEventArgs e)
         {
-            PackageEditorExperimentsO.ChangeConvoIDandConvNodeIDs(false, GetPEWindow());
+            PackageEditorExperimentsO.ChangeConvoIDandConvNodeIDsExperiment(GetPEWindow());
         }
 
         private void RenameConversation_Click(object sender, RoutedEventArgs e)
         {
-            PackageEditorExperimentsO.RenameConversation(false, GetPEWindow());
+            PackageEditorExperimentsO.RenameConversationExperiment(GetPEWindow());
         }
 
         private void RenameWwiseBank_Click(object sender, RoutedEventArgs e)
         {
-            PackageEditorExperimentsO.RenameWwiseBank(false, GetPEWindow());
+            PackageEditorExperimentsO.RenameWwiseBankExperiment(GetPEWindow());
         }
 
         private void UpdateWwiseBankID_Click (object sender, RoutedEventArgs e)
         {
-            PackageEditorExperimentsO.UpdateWwiseBankID(false, GetPEWindow());
+            PackageEditorExperimentsO.UpdateWwiseBankIDExperiment(GetPEWindow());
         }
         #endregion
 

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
@@ -1384,6 +1384,11 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
         {
             PackageEditorExperimentsO.SMRefRemover(GetPEWindow());
         }
+
+        private void CleanConvoDonor_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.CleanConvoDonor(GetPEWindow());
+        }
         #endregion
 
         // EXPERIMENTS: CHONKY DB---------------------------------------------------------

--- a/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/WwiseBank.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/WwiseBank.cs
@@ -430,7 +430,7 @@ namespace LegendaryExplorerCore.Unreal.BinaryConverters
             public HIRCType Type;
             public uint ID;
             public virtual int DataLength(MEGame game) => unparsed.Length + 4;
-            protected byte[] unparsed;
+            public byte[] unparsed;
 
             public static HIRCObject Create(SerializingContainer2 sc)
             {


### PR DESCRIPTION
The main experiment allows for stripping a BioConversation of everything that is not strictly needed for it to work, allowing you to not bring unnecessary stuff when cloning them to other files. It also renames everything related to it with the goal of allowing you to use it even if the original was loaded into memory, though for the moment that isn't fixing it, so right now it's just an aesthethics thing. 
The other experiments are the steps required for the main experiment abstracted so they can be used independently.
These experiments have been tested and work fine, and for LE1/ME1 I don't touch anything related to the audio at the moment, just in case.

To expand a bit more on the renaming thing: In theory if we rename everything and change the Bank ID and ensure that the original doesn't appear anywhere anymore in the cloned convo, it shouldn't have issues existing alongside the original when loaded in memory, but, for some reason, in the tests we've done so far it still doesn't work. I'll try to figure it out in the future and make another PR with the improvements.