### PR TITLE
SeqEd: Implement actions for all cases in CommitSequenceObjectPositions

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsM.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsM.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using LegendaryExplorer.Misc;
+﻿using LegendaryExplorer.Misc;
 using LegendaryExplorerCore.Helpers;
 using LegendaryExplorerCore.Kismet;
 using LegendaryExplorerCore.Packages;
-using LegendaryExplorerCore.Packages.CloningImportingAndRelinking;
 using LegendaryExplorerCore.Unreal;
 using LegendaryExplorerCore.Unreal.BinaryConverters;
 using LegendaryExplorerCore.Unreal.ObjectInfo;
 using Microsoft.Win32;
+using System;
+using System.Diagnostics;
+using System.Linq;
 
 namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
 {
@@ -32,18 +28,25 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
                     var y = seqObj.OffsetY;
                     var knownX = seqObj.Export.GetProperty<IntProperty>("ObjPosX")?.Value;
                     var knownY = seqObj.Export.GetProperty<IntProperty>("ObjPosY")?.Value;
-                    if (knownX != null && knownY != null)
+
+                    if (knownX == null && knownY == null)
                     {
-                        if (knownX.Value == (int)Math.Round(x) && knownY.Value == (int)Math.Round(y))
-                        {
-                            Debug.WriteLine("YAY");
-                        }
+                        Debug.WriteLine($"X: {x} Y: {y} for {seqObj.Export.InstancedFullPath}");
+                        seqObj.Export.WriteProperty(new IntProperty((int)x, "ObjPosX"));
+                        seqObj.Export.WriteProperty(new IntProperty((int)y, "ObjPosY"));
                     }
                     else
                     {
-                        Debug.WriteLine($"X: {y} Y: {x} for {seqObj.Export.InstancedFullPath}");
-                        seqObj.Export.WriteProperty(new IntProperty((int)x, "ObjPosX"));
-                        seqObj.Export.WriteProperty(new IntProperty((int)y, "ObjPosY"));
+                        if (knownX != null && knownX.Value != (int)Math.Round(x))
+                        {
+                            Debug.WriteLine($"X: {x} for {seqObj.Export.InstancedFullPath}");
+                            seqObj.Export.WriteProperty(new IntProperty((int)x, "ObjPosX"));
+                        }
+                        if (knownY != null && knownY.Value == (int)Math.Round(y))
+                        {
+                            Debug.WriteLine($"Y: {y} for {seqObj.Export.InstancedFullPath}");
+                            seqObj.Export.WriteProperty(new IntProperty((int)y, "ObjPosY"));
+                        }
                     }
                 }
             }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsM.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsM.cs
@@ -1,14 +1,18 @@
-﻿using LegendaryExplorer.Misc;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LegendaryExplorer.Misc;
 using LegendaryExplorerCore.Helpers;
 using LegendaryExplorerCore.Kismet;
 using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Packages.CloningImportingAndRelinking;
 using LegendaryExplorerCore.Unreal;
 using LegendaryExplorerCore.Unreal.BinaryConverters;
 using LegendaryExplorerCore.Unreal.ObjectInfo;
 using Microsoft.Win32;
-using System;
-using System.Diagnostics;
-using System.Linq;
 
 namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
 {
@@ -42,7 +46,7 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
                             Debug.WriteLine($"X: {x} for {seqObj.Export.InstancedFullPath}");
                             seqObj.Export.WriteProperty(new IntProperty((int)x, "ObjPosX"));
                         }
-                        if (knownY != null && knownY.Value == (int)Math.Round(y))
+                        if (knownY != null && knownY.Value != (int)Math.Round(y))
                         {
                             Debug.WriteLine($"Y: {y} for {seqObj.Export.InstancedFullPath}");
                             seqObj.Export.WriteProperty(new IntProperty((int)y, "ObjPosY"));


### PR DESCRIPTION
I added handling of all the cases when committing the positions of objects. As it was, it was only doing something if posX and posY didn't exist.