### PR TITLE
Fix bug when ReferencedBanks is null when serializing a WwiseBank

### DIFF
--- a/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/WwiseBank.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/WwiseBank.cs
@@ -374,7 +374,7 @@ namespace LegendaryExplorerCore.Unreal.BinaryConverters
                 sc.ms.JumpTo(endPos);
             }
 
-            if (ReferencedBanks.Count > 0)
+            if (ReferencedBanks.IsNull() && ReferencedBanks.Count > 0)
             {
                 writer.WriteUInt32(stid);
                 var lengthPos = sc.ms.Position;


### PR DESCRIPTION
As reported by beccatoria, when serializing WwiseBanks the program could encounter an error if the ReferencedBanks is not assigned any values, so I added a small check.