### PR TITLE
PackageEd: Update experiment to clean conversations

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/Tools/Dialogue Editor/DialogueEditorExperiments/DialogueEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Dialogue Editor/DialogueEditorExperiments/DialogueEditorExperimentsE.cs
@@ -29,6 +29,12 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
 
             if (dew.Pcc == null || selectedDialogueNode == null) { return; }
 
+            if (dew.Pcc.Game.IsGame1())
+            {
+                MessageBox.Show("Not available for Mass Effect 1.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
             // Need to check if currStringRef exists
             string currStringRef = selectedDialogueNode.LineStrRef.ToString();
             if (string.IsNullOrEmpty(currStringRef))

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1761,7 +1761,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             List<ExportEntry> wwiseEvents = GetWwiseEvents(pcc, fxas);
             List<ExportEntry> wwiseStreams = GetWwiseStreams(pcc, wwiseEvents);
 
-            RenameWwiseEvents(pcc, wwiseEvents, newName);
+            // RenameWwiseEvents(pcc, wwiseEvents, newName);
             RenameWwiseStreams(pcc, wwiseStreams, oldName, newName);
 
             if (updateAudioIDs)
@@ -1788,7 +1788,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         {
             string oldBankName = wwiseBankEntry.ObjectName;
 
-            (uint oldBankID, uint newBankID) = UpdateID(wwiseBankEntry);
+            (uint oldBankID, uint newBankID) = UpdateID(wwiseBankEntry, newWwiseBankName);
 
             WwiseBank wwiseBank = wwiseBankEntry.GetBinaryData<WwiseBank>();
             // Update the bank id

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1821,7 +1821,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 else if (hirc.Type == HIRCType.SoundSXFSoundVoice) // References a WwiseStream
                 {
                     // 4 bytes ID is located at the start after 14 bytes
-                    Span<byte> streamIDSpan = hirc.unparsed.AsSpan(15..19);
+                    Span<byte> streamIDSpan = hirc.unparsed.AsSpan(5..9);
                     uint streamIDUInt = BitConverter.ToUInt32(streamIDSpan);
 
                     if (wwiseStreamIDs.TryGetValue(streamIDUInt, out uint newStreamIDUInt))
@@ -1858,7 +1858,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             {
                 if (!pcc.Game.IsGame1())
                 {
-                    wwiseEvent.ObjectName = $"{wwiseEvent.ObjectName.Name}";
+                    wwiseEvent.ObjectName = $"I{wwiseEvent.ObjectName.Name}";
                 }
             }
         }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -2134,7 +2134,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                         }
                         else
                         {
-                            if (line.Index <= 0 || eventRefs[line.Index].Value <= 0) { continue; }
+                            if (line.Index < 0 || eventRefs[line.Index].Value <= 0) { continue; }
                             soundEvent = pcc.GetUExport(eventRefs[line.Index].Value);
                         }
 

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1115,9 +1115,9 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             if (!pew.Pcc.Game.IsGame1())
             {
                 updateAudioIDs = MessageBoxResult.Yes == MessageBox.Show(
-                "Update the IDs of the WwiseBank, WwiseEvents, and WwiseStreams?\nIn general it's safe and better to do so, but there may be edge cases" +
+                "Update the IDs of the WwiseBank?\nIn general it's safe and better to do so, but there may be edge cases" +
                 "where doing so may overwrite parts of the WwiseBank binary that are not the IDs.",
-                "Update audio IDs", MessageBoxButton.YesNo);
+                "Update WwiseBank ID", MessageBoxButton.YesNo);
             }
 
             bool bringTrash = MessageBoxResult.No == MessageBox.Show(
@@ -1597,9 +1597,9 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             if (!pew.Pcc.Game.IsGame1())
             {
                 updateAudioIDs = MessageBoxResult.Yes == MessageBox.Show(
-                "Change the IDs of the WwiseBank, WwiseEvents, and WwiseStreams?\nIn general it's safe and better to do so, but there may be edge cases" +
+                "Update the IDs of the WwiseBank?\nIn general it's safe and better to do so, but there may be edge cases" +
                 "where doing so may overwrite parts of the WwiseBank binary that are not the IDs.",
-                "Update audio IDs", MessageBoxButton.YesNo);
+                "Update WwiseBank ID", MessageBoxButton.YesNo);
             }
 
             ExportEntry bioConversation = (ExportEntry)pew.SelectedItem.Entry;
@@ -1714,9 +1714,9 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             if (!pew.Pcc.Game.IsGame1())
             {
                 updateAudioIDs = MessageBoxResult.Yes == MessageBox.Show(
-                "Change the IDs of the WwiseBank, WwiseEvents, and WwiseStreams?\nIn general it's safe and better to do so, but there may be edge cases" +
+                "Update the IDs of the WwiseBank?\nIn general it's safe and better to do so, but there may be edge cases" +
                 "where doing so may overwrite parts of the WwiseBank binary that are not the IDs.",
-                "Update audio IDs", MessageBoxButton.YesNo);
+                "Update WwiseBank ID", MessageBoxButton.YesNo);
             }
 
             string newName = PromptDialog.Prompt(null, "New common name:", "New name");
@@ -1766,68 +1766,14 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
             if (updateAudioIDs)
             {
-                Dictionary<uint, uint> wwiseEventsIDs = UpdateIDs(wwiseEvents);
-                Dictionary<uint, uint> wwiseStreamsIDs = UpdateIDs(wwiseStreams);
+                // Dictionary<uint, uint> wwiseEventsIDs = UpdateIDs(wwiseEvents);
+                // Dictionary<uint, uint> wwiseStreamsIDs = UpdateIDs(wwiseStreams);
 
-                UpdateAudioIDs(wwiseBankEntry, newWwiseBankName, wwiseEventsIDs, wwiseStreamsIDs);
+                UpdateAudioIDs(wwiseBankEntry, newWwiseBankName, null, null);
             }
 
             wwiseBankEntry.ObjectName = newWwiseBankName;
             RenameFXAs(pcc, bioConversation, oldName, newName);
-        }
-
-        public static Dictionary<uint, uint> GatherIDs(ExportEntry wwiseBankEntry)
-        {
-            WwiseBank wwiseBank = wwiseBankEntry.GetBinaryData<WwiseBank>();
-            Dictionary<uint, uint> IDs = new();
-
-
-            foreach (WwiseBank.HIRCObject hirc in wwiseBank.HIRCObjects.Values())
-            {
-                switch (hirc.Type)
-                {
-                    case HIRCType.Settings:
-                        break;
-                    case HIRCType.SoundSXFSoundVoice:
-                        break;
-                    case HIRCType.EventAction:
-                        break;
-                    case HIRCType.Event:
-                        break;
-                    case HIRCType.RandomOrSequenceContainer:
-                        break;
-                    case HIRCType.SwitchContainer:
-                        break;
-                    case HIRCType.ActorMixer:
-                        break;
-                    case HIRCType.AudioBus:
-                        break;
-                    case HIRCType.BlendContainer:
-                        break;
-                    case HIRCType.MusicSegment:
-                        break;
-                    case HIRCType.MusicTrack:
-                        break;
-                    case HIRCType.MusicSwitchContainer:
-                        break;
-                    case HIRCType.MusicPlaylistContainer:
-                        break;
-                    case HIRCType.Attenuation:
-                        break;
-                    case HIRCType.DialogueEvent:
-                        break;
-                    case HIRCType.MotionBus:
-                        break;
-                    case HIRCType.MotionFX:
-                        break;
-                    case HIRCType.Effect:
-                        break;
-                    case HIRCType.AuxiliaryBus:
-                        break;
-                }
-            }
-
-            return new();
         }
 
         /// <summary>
@@ -1860,33 +1806,33 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 });
             wwiseBank.ReferencedBanks = new(updatedBanks);
 
-            // Update references to old wwiseEvents' hashes, which are the ID of Event HIRCs,
-            // update references to old wwiseStreams' hashes, which are in the unknown bytes of Sound HIRCs, 
-            // update references to old bank hash, which I'm certain is at the end of Event Action HIRCs,
+            // DISABLED: Update references to old wwiseEvents' hashes, which are the ID of Event HIRCs.
+            // DISABLED: Update references to old wwiseStreams' hashes, which are in the unknown bytes of Sound HIRCs.
+            // Update references to old bank hash, which I'm certain is at the end of Event Action HIRCs,
             // but we check in all of them just in case.
             byte[] bankIDArr = BitConverter.GetBytes(oldBankID);
             byte[] newBankIDArr = BitConverter.GetBytes(newBankID);
-            foreach (WwiseBank.HIRCObject hirc in wwiseBank.HIRCObjects.Values())
+            foreach (WwiseBank.HIRCObject hirc in wwiseBank.HIRCObjects.Values)
             {
-                if (hirc.Type == HIRCType.Event) // References a WwiseEvent
-                {
-                    if (wwiseEventIDs.TryGetValue(hirc.ID, out uint newEventID))
-                    {
-                        hirc.ID = newEventID;
-                    }
-                }
-                else if (hirc.Type == HIRCType.SoundSXFSoundVoice) // References a WwiseStream
-                {
-                    // 4 bytes ID is located at the start after 14 bytes
-                    Span<byte> streamIDSpan = hirc.unparsed.AsSpan(5..9);
-                    uint streamIDUInt = BitConverter.ToUInt32(streamIDSpan);
+                //if (hirc.Type == HIRCType.Event) // References a WwiseEvent
+                //{
+                //    if (wwiseEventIDs.TryGetValue(hirc.ID, out uint newEventID))
+                //    {
+                //        hirc.ID = newEventID;
+                //    }
+                //}
+                //else if (hirc.Type == HIRCType.SoundSXFSoundVoice) // References a WwiseStream
+                //{
+                //    // 4 bytes ID is located at the start after 14 bytes
+                //    Span<byte> streamIDSpan = hirc.unparsed.AsSpan(5..9);
+                //    uint streamIDUInt = BitConverter.ToUInt32(streamIDSpan);
 
-                    if (wwiseStreamIDs.TryGetValue(streamIDUInt, out uint newStreamIDUInt))
-                    {
-                        byte[] newStreamIDArr = BitConverter.GetBytes(newStreamIDUInt);
-                        newStreamIDArr.CopyTo(streamIDSpan);
-                    }
-                }
+                //    if (wwiseStreamIDs.TryGetValue(streamIDUInt, out uint newStreamIDUInt))
+                //    {
+                //        byte[] newStreamIDArr = BitConverter.GetBytes(newStreamIDUInt);
+                //        newStreamIDArr.CopyTo(streamIDSpan);
+                //    }
+                //}
 
                 // Check for bank ID in all HIRCs, even though I'm almost certain it only appears
                 // in Event Actions

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1652,7 +1652,8 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 ExportEntry tlkFileSet = null;
                 if (m_oTlkFileSet != null && m_oTlkFileSet.Value != 0 && pcc.TryGetUExport(m_oTlkFileSet.Value, out tlkFileSet))
                 {
-                    tlkFileSet.ObjectNameString = tlkFileSet.ObjectNameString.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    string name = tlkFileSet.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    tlkFileSet.ObjectName = new NameReference(name, tlkFileSet.ObjectName.Number);
                 }
 
                 RenameISACTAudio(pcc, bioConversation, tlkFileSet, oldName, newName, conversation);
@@ -1722,7 +1723,8 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 ExportEntry link = pcc.GetUExport(bioConversation.idxLink);
                 if (link.ClassName == "Package")
                 {
-                    link.ObjectName = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    string name = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    link.ObjectName = new NameReference(name, link.ObjectName.Number);
                 }
             }
 
@@ -1732,7 +1734,8 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 ExportEntry link = pcc.GetUExport(conversation.Sequence.idxLink);
                 if (link.ClassName == "Package")
                 {
-                    link.ObjectName = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    string name = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    link.ObjectName = new NameReference(name, link.ObjectName.Number);
                 }
             }
             // Replace name of the sounds package, which is separate in ME2
@@ -1741,7 +1744,8 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 ExportEntry link = pcc.GetUExport(conversation.WwiseBank.idxLink);
                 if (link.ClassName == "Package")
                 {
-                    link.ObjectName = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    string name = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    link.ObjectName = new NameReference(name, link.ObjectName.Number);
                 }
             }
         }
@@ -1783,6 +1787,15 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             // operate on. Is it overkill? Yes. Does it get the job done more cleanly and safely? yes.
             ConversationExtended conversation = new(bioConversation);
             conversation.LoadConversation(TLKManagerWPF.GlobalFindStrRefbyID, true);
+
+            // Check that the conversation has a normal package structure. Otherwise it can lead to unexpected edge cases when trying to gather
+            // the different sound elements.
+            string structureCheckResult = CheckConversationStructure(pew.Pcc, bioConversation, conversation);
+            if (!string.IsNullOrEmpty(structureCheckResult))
+            {
+                ShowError(structureCheckResult);
+                return;
+            }
 
             string oldName = GetOldName(pew.Pcc, bioConversation, conversation);
 
@@ -1944,7 +1957,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             {
                 if (!pcc.Game.IsGame1())
                 {
-                    wwiseEvent.ObjectName = $"I{wwiseEvent.ObjectName.Name}";
+                    wwiseEvent.ObjectName = new NameReference($"I{wwiseEvent.ObjectName.Name}", wwiseEvent.ObjectName.Number);
                 }
             }
         }
@@ -1962,7 +1975,9 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             {
                 if (!pcc.Game.IsGame1())
                 {
-                    wwiseStream.ObjectName = wwiseStream.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    string name = wwiseStream.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                    wwiseStream.ObjectName = new NameReference(name, wwiseStream.ObjectName.Number);
+
                     if (pcc.Game.IsGame2())
                     {
                         NameProperty bankName = wwiseStream.GetProperty<NameProperty>("BankName");
@@ -1985,7 +2000,8 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         {
             foreach (ExportEntry nodeWave in nodeWaves)
             {
-                nodeWave.ObjectNameString = nodeWave.ObjectNameString.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                string name = nodeWave.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+                nodeWave.ObjectName = new NameReference(name, nodeWave.ObjectName.Number);
             }
         }
 

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1776,6 +1776,60 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             RenameFXAs(pcc, bioConversation, oldName, newName);
         }
 
+        public static Dictionary<uint, uint> GatherIDs(ExportEntry wwiseBankEntry)
+        {
+            WwiseBank wwiseBank = wwiseBankEntry.GetBinaryData<WwiseBank>();
+            Dictionary<uint, uint> IDs = new();
+
+
+            foreach (WwiseBank.HIRCObject hirc in wwiseBank.HIRCObjects.Values())
+            {
+                switch (hirc.Type)
+                {
+                    case HIRCType.Settings:
+                        break;
+                    case HIRCType.SoundSXFSoundVoice:
+                        break;
+                    case HIRCType.EventAction:
+                        break;
+                    case HIRCType.Event:
+                        break;
+                    case HIRCType.RandomOrSequenceContainer:
+                        break;
+                    case HIRCType.SwitchContainer:
+                        break;
+                    case HIRCType.ActorMixer:
+                        break;
+                    case HIRCType.AudioBus:
+                        break;
+                    case HIRCType.BlendContainer:
+                        break;
+                    case HIRCType.MusicSegment:
+                        break;
+                    case HIRCType.MusicTrack:
+                        break;
+                    case HIRCType.MusicSwitchContainer:
+                        break;
+                    case HIRCType.MusicPlaylistContainer:
+                        break;
+                    case HIRCType.Attenuation:
+                        break;
+                    case HIRCType.DialogueEvent:
+                        break;
+                    case HIRCType.MotionBus:
+                        break;
+                    case HIRCType.MotionFX:
+                        break;
+                    case HIRCType.Effect:
+                        break;
+                    case HIRCType.AuxiliaryBus:
+                        break;
+                }
+            }
+
+            return new();
+        }
+
         /// <summary>
         /// Update a WwiseBank's ID by hashing a new name and changing it in the binary data where appropriate.
         /// </summary>

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -573,7 +573,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             string baldMorphName = game.IsGame3() ? "BioChar_CitHub.Faces.HMM_Deco_1" :
                 game.IsGame2() ? "BIOG_Hench_FAC.HMM.hench_wilson" : "BIOA_UNC_FAC.HMM.Plot.FRE32_BioticLeader";
 
-            MorphMaleHair(pew,"bald", baldPccPath, baldMorphName);
+            MorphMaleHair(pew, "bald", baldPccPath, baldMorphName);
         }
 
         /// <summary>
@@ -592,7 +592,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             string rollinMorphName = game.IsGame3() ? "BioChar_CitHub.Faces.cit_news_announcer" :
                 game.IsGame2() ? "BIOA_STA_FAC.HMM.Plot.rp107_keeler" : "BIOA_STA_FAC.HMM.Plot.rp107_keeler";
 
-            MorphMaleHair(pew,"rollins", rollinPccPath, rollinMorphName);
+            MorphMaleHair(pew, "rollins", rollinPccPath, rollinMorphName);
         }
 
         /// <summary>
@@ -1518,39 +1518,45 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
             // Update the nExportIDs of the Entry list
             ArrayProperty<StructProperty> entryNodes = conversationProps.GetProp<ArrayProperty<StructProperty>>("m_EntryList");
-            foreach (StructProperty entryNode in entryNodes)
+            if (entryNodes != null)
             {
-                IntProperty oldNodeID = entryNode.GetProp<IntProperty>("nExportID");
-                if (oldNodeID == null) { continue; }
-
-                if (!remappedIDs.ContainsKey(oldNodeID.Value))
+                foreach (StructProperty entryNode in entryNodes)
                 {
-                    remappedIDs.Add(oldNodeID.Value, convNodeIDBase + count);
-                    count++;
-                }
+                    IntProperty oldNodeID = entryNode.GetProp<IntProperty>("nExportID");
+                    if (oldNodeID == null) { continue; }
 
-                PropertyCollection properties = entryNode.Properties;
-                IntProperty nExportID = new(remappedIDs[oldNodeID.Value], "nExportID");
-                properties.AddOrReplaceProp(nExportID);
-                entryNode.Properties = properties;
+                    if (!remappedIDs.ContainsKey(oldNodeID.Value))
+                    {
+                        remappedIDs.Add(oldNodeID.Value, convNodeIDBase + count);
+                        count++;
+                    }
+
+                    PropertyCollection properties = entryNode.Properties;
+                    IntProperty nExportID = new(remappedIDs[oldNodeID.Value], "nExportID");
+                    properties.AddOrReplaceProp(nExportID);
+                    entryNode.Properties = properties;
+                }
             }
 
             // Update the nExportIDs of the Reply list
             ArrayProperty<StructProperty> replyNodes = conversationProps.GetProp<ArrayProperty<StructProperty>>("m_ReplyList");
-            foreach (StructProperty replyNode in replyNodes)
+            if (replyNodes != null)
             {
-                IntProperty oldNodeID = replyNode.GetProp<IntProperty>("nExportID");
-                if (oldNodeID == null) { continue; }
-                if (!remappedIDs.ContainsKey(oldNodeID.Value))
+                foreach (StructProperty replyNode in replyNodes)
                 {
-                    remappedIDs.Add(oldNodeID.Value, convNodeIDBase + count);
-                    count++;
-                }
+                    IntProperty oldNodeID = replyNode.GetProp<IntProperty>("nExportID");
+                    if (oldNodeID == null) { continue; }
+                    if (!remappedIDs.ContainsKey(oldNodeID.Value))
+                    {
+                        remappedIDs.Add(oldNodeID.Value, convNodeIDBase + count);
+                        count++;
+                    }
 
-                PropertyCollection properties = replyNode.Properties;
-                IntProperty nExportID = new(remappedIDs[oldNodeID.Value], "nExportID");
-                properties.AddOrReplaceProp(nExportID);
-                replyNode.Properties = properties;
+                    PropertyCollection properties = replyNode.Properties;
+                    IntProperty nExportID = new(remappedIDs[oldNodeID.Value], "nExportID");
+                    properties.AddOrReplaceProp(nExportID);
+                    replyNode.Properties = properties;
+                }
             }
 
             bioConversation.WriteProperties(conversationProps);

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1816,8 +1816,8 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 }
                 else if (hirc.Type == HIRCType.SoundSXFSoundVoice) // References a WwiseStream
                 {
-                    // 4 bytes ID is located at the start after 5 bytes
-                    Span<byte> streamIDSpan = hirc.unparsed.AsSpan(5..9);
+                    // 4 bytes ID is located at the start after 14 bytes
+                    Span<byte> streamIDSpan = hirc.unparsed.AsSpan(15..19);
                     uint streamIDUInt = BitConverter.ToUInt32(streamIDSpan);
 
                     if (wwiseStreamIDs.TryGetValue(streamIDUInt, out uint newStreamIDUInt))

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1650,12 +1650,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             else
             {
                 oldName = GetCommonPrefix(conversation.WwiseBank.ObjectName, bioConversation.ObjectName);
-                RenameAudio(pcc, conversation.WwiseBank, bioConversation, newName, updateAudioIDs);
             }
-
-            // Rename bioConversation after the audio, since it needs the old name
-            string newBioConversationName = oldBioConversationName.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
-            bioConversation.ObjectName = newBioConversationName;
 
             // Replace package's name
             if (bioConversation.idxLink != 0)
@@ -1684,6 +1679,15 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                     link.ObjectName = link.ObjectName.Name.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
                 }
             }
+
+            if (!pcc.Game.IsGame1())
+            {
+                RenameAudio(pcc, conversation.WwiseBank, bioConversation, newName, updateAudioIDs);
+            }
+
+            // Rename bioConversation after the audio, since it needs the old name
+            string newBioConversationName = oldBioConversationName.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+            bioConversation.ObjectName = newBioConversationName;
         }
 
         /// <summary>
@@ -1993,8 +1997,8 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 List<string> names = faceFXAnimSet.Names.Select(name => name == oldFxaName ? newFxaName : name).ToList();
                 faceFXAnimSet.Names = names;
 
-                // Set the paths with the new names and update the names of WwiseStreams
                 ArrayProperty<ObjectProperty> eventRefs = fxaExport.GetProperty<ArrayProperty<ObjectProperty>>("ReferencedSoundCues");
+                // Set the paths with the new names and update the names of WwiseStreams
                 if (eventRefs != null)
                 {
                     foreach (FaceFXLine line in faceFXAnimSet.Lines)

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -2120,6 +2120,12 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 {
                     foreach (FaceFXLine line in faceFXAnimSet.Lines)
                     {
+                        // Update the ID for ME1
+                        if (pcc.Game.IsGame1())
+                        {
+                            line.ID = line.ID.Replace(oldName, newName);
+                        }
+
                         ExportEntry soundEvent;
                         if (pcc.Game is MEGame.ME2)
                         {

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -1858,7 +1858,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             {
                 if (!pcc.Game.IsGame1())
                 {
-                    wwiseEvent.ObjectName = $"{prefix}{wwiseEvent.ObjectName.Name}";
+                    wwiseEvent.ObjectName = $"{wwiseEvent.ObjectName.Name}";
                 }
             }
         }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -2112,7 +2112,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                         }
                         else
                         {
-                            if (eventRefs[line.Index].Value == 0) { continue; }
+                            if (line.Index <= 0 || eventRefs[line.Index].Value <= 0) { continue; }
                             soundEvent = pcc.GetUExport(eventRefs[line.Index].Value);
                         }
 

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -178,8 +178,8 @@
         <MenuItem Header="Clean Sequence" Click="CleanSequence_Click" ToolTip="Cleans a sequence of objects that are not ConvNode, Interp, InterpData, and ConvNodeEnd; and optionally, of non-Conversation InterpGroups and non-VOElements InterpTracks."/>
         <MenuItem Header="Clean Sequence's InterpDatas" Click="CleanSequenceInterpDatas_Click" ToolTip="Clean a sequence of non-Conversation InterpGroups and non-VOElements InterpTracks."/>
         <MenuItem Header="Change Conversation ID and ConvNodes' ID" Click="ChangeConvoIDandConvNodeIDs_Click" ToolTip="Change a conversation's ConvResRefID and give its ConvNodes a new ID range."/>
-        <MenuItem Header="Rename Conversation" Click="RenameConversation_Click" ToolTip="Rename a conversation, changing the WwiseBank name and FXAs and related elements too, and optionally, updating its WwiseBank ID."/>
-        <MenuItem Header="Rename Audio" Click="RenameAudio_Click" ToolTip="Renames the WwiseBank, WwiseEvents, and WwiseStreams, and optionally udpate the WwiseBank ID."/>
+        <MenuItem Header="Rename Conversation" Click="RenameConversation_Click" ToolTip="Rename a conversation, changing the name of all related elements, and optionally updating its WwiseBank ID, if not in ME1."/>
+        <MenuItem Header="Rename Audio" Click="RenameAudio_Click" ToolTip="Renames the exports related to the audio of the conversation, and optionally udpate the WwiseBank ID, if not in ME1."/>
     </MenuItem>
     <MenuItem Header="Object Database">
         <MenuItem Header="Build ME1 Object Database" Click="ChonkyDB_BuildME1GameDB"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -179,7 +179,7 @@
         <MenuItem Header="Clean Sequence's InterpDatas" Click="CleanSequenceInterpDatas_Click" ToolTip="Clean a sequence of non-Conversation InterpGroups and non-VOElements InterpTracks."/>
         <MenuItem Header="Change Conversation ID and ConvNodes' ID" Click="ChangeConvoIDandConvNodeIDs_Click" ToolTip="Change a conversation's ConvResRefID and give its ConvNodes a new ID range."/>
         <MenuItem Header="Rename Conversation" Click="RenameConversation_Click" ToolTip="Rename a conversation, changing the WwiseBank name and FXAs and related elements too, and optionally, updating its WwiseBank ID."/>
-        <MenuItem Header="Rename Audio" Click="RenameAudio_Click" ToolTip="Renames the WwiseBank, WwiseEvents, and WwiseStreams, and optionally udpate their IDs."/>
+        <MenuItem Header="Rename Audio" Click="RenameAudio_Click" ToolTip="Renames the WwiseBank, WwiseEvents, and WwiseStreams, and optionally udpate the WwiseBank ID."/>
     </MenuItem>
     <MenuItem Header="Object Database">
         <MenuItem Header="Build ME1 Object Database" Click="ChonkyDB_BuildME1GameDB"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -179,8 +179,7 @@
         <MenuItem Header="Clean Sequence's InterpDatas" Click="CleanSequenceInterpDatas_Click" ToolTip="Clean a sequence of non-Conversation InterpGroups and non-VOElements InterpTracks."/>
         <MenuItem Header="Change Conversation ID and ConvNodes' ID" Click="ChangeConvoIDandConvNodeIDs_Click" ToolTip="Change a conversation's ConvResRefID and give its ConvNodes a new ID range."/>
         <MenuItem Header="Rename Conversation" Click="RenameConversation_Click" ToolTip="Rename a conversation, changing the WwiseBank name and FXAs and related elements too, and optionally, updating its WwiseBank ID."/>
-        <MenuItem Header="Rename WwiseBank" Click="RenameWwiseBank_Click" ToolTip="Rename a WwiseBank, and optionally udate its ID."/>
-        <MenuItem Header="Update WwiseBank's ID" Click="UpdateWwiseBankID_Click" ToolTip="Udate a WwiseBank's ID."/>
+        <MenuItem Header="Rename Audio" Click="RenameAudio_Click" ToolTip="Renames the WwiseBank, WwiseEvents, and WwiseStreams, and optionally udpate their IDs."/>
     </MenuItem>
     <MenuItem Header="Object Database">
         <MenuItem Header="Build ME1 Object Database" Click="ChonkyDB_BuildME1GameDB"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
@@ -1450,14 +1450,9 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
             PackageEditorExperimentsO.RenameConversationExperiment(GetPEWindow());
         }
 
-        private void RenameWwiseBank_Click(object sender, RoutedEventArgs e)
+        private void RenameAudio_Click(object sender, RoutedEventArgs e)
         {
-            PackageEditorExperimentsO.RenameWwiseBankExperiment(GetPEWindow());
-        }
-
-        private void UpdateWwiseBankID_Click(object sender, RoutedEventArgs e)
-        {
-            PackageEditorExperimentsO.UpdateWwiseBankIDExperiment(GetPEWindow());
+            PackageEditorExperimentsO.RenameAudioExperiment(GetPEWindow());
         }
         #endregion
 


### PR DESCRIPTION
This PR implements handling of ME1/LE1 audio for the conversation experiments in the PE, and the related change stringRef experiment in the DE. It adds checks and handling of more edge cases. And it refactors a lot of the code in order to have better separation of concerns in the FXA method, and better gathering of all the audio elements, in preparation for allowing giving new IDs to all WwiseBank elements in the future.