### PR TITLE
Add multiple experiments to the Package, Dialogue, and Interp Editors

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/DialogueAutomations.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/DialogueAutomations.cs
@@ -1,0 +1,952 @@
+﻿using ICSharpCode.AvalonEdit.Rendering;
+using LegendaryExplorer.DialogueEditor.DialogueEditorExperiments;
+using LegendaryExplorer.Tools.TlkManagerNS;
+using LegendaryExplorer.UserControls.ExportLoaderControls;
+using LegendaryExplorer.UserControls.SharedToolControls.Curves;
+using LegendaryExplorerCore.Dialogue;
+using LegendaryExplorerCore.Gammtek.Extensions.Collections.Generic;
+using LegendaryExplorerCore.Helpers;
+using LegendaryExplorerCore.Matinee;
+using LegendaryExplorerCore.Misc;
+using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Unreal;
+using LegendaryExplorerCore.Unreal.BinaryConverters;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Xml.Linq;
+
+using static LegendaryExplorer.Misc.ExperimentsTools.SharedMethods;
+
+namespace LegendaryExplorer.Misc.ExperimentsTools
+{
+    public static class DialogueAutomations
+    {
+        /// <summary>
+        /// Replace the line of a conversation node, along with its asociated audio, if passed.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="node">Dialogue node to operate on.</param>
+        /// <param name="newTlkID">New TLK to replace.</param>
+        /// <param name="audioInfo">Audio info to replace with.</param>
+        /// <param name="FXAControl_F">Female FaceFX controls, with a loaded export.</param>
+        /// <param name="FXAControl_M">Male FaceFX controls, with a loaded export.</param>
+        public static void ReplaceLineAndAudio(IMEPackage pcc, DialogueNodeExtended node, string newTlkID,
+            LineAudioInfo audioInfo, FaceFXAnimSetEditorControl FXAControl_F, FaceFXAnimSetEditorControl FXAControl_M)
+        {
+            FXAControl_F.SelectLineByName(node.FaceFX_Female ?? "");
+            FXAControl_M.SelectLineByName(node.FaceFX_Male ?? "");
+            string currTlkID = node.LineStrRef.ToString();
+
+            ExportEntry femaleEvent = DialogueEditorExperimentsE.GetWwiseEvent(pcc, FXAControl_F.SelectedLine);
+            ExportEntry maleEvent = DialogueEditorExperimentsE.GetWwiseEvent(pcc, FXAControl_M.SelectedLine);
+            ExportEntry femaleStream = DialogueEditorExperimentsE.GetWwiseStream(pcc, femaleEvent, currTlkID, "_f_");
+            ExportEntry maleStream = DialogueEditorExperimentsE.GetWwiseStream(pcc, maleEvent, currTlkID, "_m_");
+
+            DialogueEditorExperimentsE.UpdateWwiseEvent(pcc, femaleEvent, currTlkID, newTlkID);
+            DialogueEditorExperimentsE.UpdateWwiseEvent(pcc, maleEvent, currTlkID, newTlkID);
+
+            DialogueEditorExperimentsE.UpdateWwiseStream(femaleStream, currTlkID, newTlkID);
+            DialogueEditorExperimentsE.UpdateWwiseStream(maleStream, currTlkID, newTlkID);
+
+            DialogueEditorExperimentsE.UpdateFaceFX(FXAControl_F, currTlkID, newTlkID);
+            DialogueEditorExperimentsE.UpdateFaceFX(FXAControl_M, currTlkID, newTlkID);
+
+            node.NodeProp.Properties.AddOrReplaceProp(new StringRefProperty(int.Parse(newTlkID), "srText"));
+
+            if (FXAControl_F.SelectedLine != null && audioInfo != null) { ReplaceAudioInfo(femaleStream, audioInfo, true); }
+            if (FXAControl_M.SelectedLine != null && audioInfo != null) { ReplaceAudioInfo(maleStream, audioInfo, false); }
+        }
+
+        /// <summary>
+        /// Replaces the audio infomation of the WwiseStream.
+        /// </summary>
+        /// <param name="wwiseStream">WwiseStream to operate on.</param>
+        /// <param name="audioInfo">Information to use to replace.</param>
+        /// <param name="isFemale">Whether to use the female or male info.</param>
+        public static void ReplaceAudioInfo(ExportEntry wwiseStream, LineAudioInfo audioInfo, bool isFemale)
+        {
+            if (wwiseStream == null) { return; }
+
+            PropertyCollection props = wwiseStream.GetProperties();
+            props.AddOrReplaceProp(new NameProperty(isFemale ? audioInfo.Filename_F : audioInfo.Filename_M, "Filename"));
+            WwiseStream binary = wwiseStream.GetBinaryData<WwiseStream>();
+            binary.DataSize = isFemale ? audioInfo.SizeOnDisk_F : audioInfo.SizeOnDisk_M;
+            wwiseStream.WritePropertiesAndBinary(props, binary);
+
+            byte[] unparsedBinary = wwiseStream.GetBinaryData();
+            Span<byte> dataOffsetSpan = unparsedBinary.AsSpan(^4..);
+            HexToBytes(isFemale ? audioInfo.OffsetInFile_F : audioInfo.OffsetInFile_M).CopyTo(dataOffsetSpan);
+            wwiseStream.WriteBinary(unparsedBinary);
+        }
+
+        /// <summary>
+        /// Replace the line of a conversation node, along with its asociated audio, and the FaceFX.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="node">Dialogue node to operate on.</param>
+        /// <param name="tlkID">New TLK to replace.</param>
+        /// <param name="lineAudioInfo">Line Audio Info to use.</param>
+        /// <param name="FXA_F_Control">Female FaceFX controls, with a loaded export.</param>
+        /// <param name="FXA_M_Control">Male FaceFX controls, with a loaded export.</param>
+        public static void ReplaceLineAndAudioAndFXA(IMEPackage pcc, DialogueNodeExtended node, string tlkID, LineAudioInfo lineAudioInfo, FaceFXAnimSetEditorControl FXA_F_Control, FaceFXAnimSetEditorControl FXA_M_Control)
+        {
+            ReplaceLineAndAudio(pcc, node, tlkID, lineAudioInfo, FXA_F_Control, FXA_M_Control);
+            // Update FaceFX and timings
+            FXA_F_Control.SelectLineByName(node.Line);
+            FXA_M_Control.SelectLineByName(node.Line);
+
+            if (lineAudioInfo.XMLUri_F.EndsWith(".xml")) { ReplaceAnimationFromXml(FXA_F_Control, lineAudioInfo.XMLUri_F); }
+            else { ReplaceAnimationFromJson(FXA_F_Control, lineAudioInfo.XMLUri_F); }
+
+            if (lineAudioInfo.XMLUri_M.EndsWith(".xml")) { ReplaceAnimationFromXml(FXA_M_Control, lineAudioInfo.XMLUri_M); }
+            else { ReplaceAnimationFromJson(FXA_M_Control, lineAudioInfo.XMLUri_M); }
+        }
+
+
+        /// <summary>
+        /// Gets the dialogue node that matches the given export ID.
+        /// </summary>
+        /// <param name="conversation">Loaded conversation to find the node in.</param>
+        /// <param name="exportID">Export ID of the node to find.</param>
+        /// <returns>Dialogue node.</returns>
+        public static DialogueNodeExtended GetNode(ConversationExtended conversation, int exportID)
+        {
+            ObservableCollection<DialogueNodeExtended> nodes = conversation.EntryList;
+            nodes.AddRange(conversation.ReplyList);
+            DialogueNodeExtended node = nodes.FirstOrDefault(node => node.ExportID == exportID);
+            return node;
+        }
+
+        /// <summary>
+        /// Gets the dialogue nodes that match the given export IDs.
+        /// </summary>
+        /// <param name="conversation">Loaded conversation to find the node in.</param>
+        /// <param name="exportID">Export IDs of the nodes to find.</param>
+        /// <returns>Dialogue nodes.</returns>
+        public static IEnumerable<DialogueNodeExtended> GetNodes(ConversationExtended conversation, int[] exportIDs)
+            => exportIDs.Select(id => GetNode(conversation, id));
+
+        /// <summary>
+        /// Get a node from a conversation by its index.
+        /// </summary>
+        /// <param name="conversation">Conversation to get the node from.</param>
+        /// <param name="index">Node's index.</param>
+        /// <param name="isReply">Whether the node is a reply or an entry node.</param>
+        /// <returns>Dialogue node.</returns>
+        public static DialogueNodeExtended GetNodeByIndex(ConversationExtended conversation, int index, bool isReply)
+            => isReply ? conversation.ReplyList[index] : conversation.EntryList[index];
+
+        /// <summary>
+        /// Get nodes from a conversation by their index.
+        /// MUST be of the same type, either Reply or Entry.
+        /// </summary>
+        /// <param name="conversation">Conversation to get the nodes from.</param>
+        /// <param name="areReply">Whether the nodes are a reply or an entry node.</param>
+        /// <param name="indexex">Nodes' index.</param>
+        /// <returns>Dialogue nodes.</returns>
+        public static IEnumerable<DialogueNodeExtended> GetNodesByIndex(ConversationExtended conversation, bool areReply, int[] indexes)
+            => indexes.Select(index => areReply ? conversation.ReplyList[index] : conversation.EntryList[index]);
+
+        /// <summary>
+        /// Writes a DialogueNodeExtended to a conversation.
+        /// </summary>
+        /// <param name="node">Node to write.</param>
+        /// <param name="conversation">Conversation to write the node to.</param>
+        public static void WriteNode(DialogueNodeExtended node, ExportEntry conversation)
+        {
+            if (node.IsReply)
+            {
+                ArrayProperty<StructProperty> m_ReplyList = conversation.GetProperty<ArrayProperty<StructProperty>>("m_ReplyList");
+                m_ReplyList.ReplaceFirstOrAdd(el => el.GetProp<IntProperty>("nExportID").Value == node.ExportID, node.NodeProp);
+                conversation.WriteProperty(m_ReplyList);
+            }
+            else
+            {
+                ArrayProperty<StructProperty> m_EntryList = conversation.GetProperty<ArrayProperty<StructProperty>>("m_EntryList");
+                m_EntryList.ReplaceFirstOrAdd(el => el.GetProp<IntProperty>("nExportID").Value == node.ExportID, node.NodeProp);
+                conversation.WriteProperty(m_EntryList);
+            }
+        }
+
+        /// <summary>
+        /// Writes multiple DialogueNodeExtended to a conversation.
+        /// </summary>
+        /// <param name="conversation">Conversation to write the node to.</param>
+        /// <param name="nodes">Nodes to write to the conversation.</param>
+        public static void WriteNodes(ExportEntry conversation, params DialogueNodeExtended[] nodes)
+        {
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                WriteNode(node, conversation);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new ConversationExtended and loads it.
+        /// </summary>
+        /// <param name="conv">Conversation to generate the extended from.</param>
+        /// <returns>Loaded ConversationExtended.</returns>
+        public static ConversationExtended GetLoadedConversation(ExportEntry conv)
+        {
+            ConversationExtended loadedConv = new(conv);
+            loadedConv.LoadConversation(TLKManagerWPF.GlobalFindStrRefbyID, true);
+            return loadedConv;
+        }
+
+        /// <summary>
+        /// Gets an FXA Control and loads the given export.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="UExport">Export to load.</param>
+        /// <returns>Loaded FaceFXAnimSetEditorControl.</returns>
+        public static FaceFXAnimSetEditorControl GetLoadedFXAControl(IMEPackage pcc, int UExport)
+        {
+            FaceFXAnimSetEditorControl FXA_Control = new();
+            FXA_Control.LoadExport(pcc.GetUExport(UExport));
+            return FXA_Control;
+        }
+
+        /// <summary>
+        /// Clears the _m animations for the FXA control.
+        /// </summary>
+        /// <param name="control">FaceFX animation set editor control.</param>
+        public static void ClearLipSyncKeys(FaceFXAnimSetEditorControl control)
+        {
+            foreach (var anim in control.Animations)
+            {
+                if (anim.Name.StartsWith("m_"))
+                {
+                    anim.Points = new LinkedList<CurvePoint>();
+                }
+            }
+            SaveChanges(control);
+        }
+
+        /// <summary>
+        /// Saves the changes to the FXA control.
+        /// </summary>
+        /// <param name="control">FaceFX animation set editor control.</param>
+        public static void SaveChanges(FaceFXAnimSetEditorControl control)
+        {
+            if (control.SelectedLine != null)
+            {
+                var curvePoints = new List<CurvePoint>();
+                var numKeys = new List<int>();
+                var animationNames = new List<int>();
+                foreach (Animation anim in control.Animations)
+                {
+                    animationNames.Add(control.FaceFX.Names.FindOrAdd(anim.Name));
+                    curvePoints.AddRange(anim.Points);
+                    numKeys.Add(anim.Points.Count);
+                }
+                control.SelectedLine.AnimationNames = animationNames;
+                control.SelectedLine.Points = curvePoints.Select(x => new FaceFXControlPoint
+                {
+                    time = x.InVal,
+                    weight = x.OutVal,
+                    inTangent = x.ArriveTangent,
+                    leaveTangent = x.LeaveTangent
+                }).ToList();
+                control.SelectedLine.NumKeys = numKeys;
+                control.SelectedLineEntry.UpdateLength();
+            }
+            control.CurrentLoadedExport?.WriteBinary(control.FaceFX.Binary);
+        }
+
+        /// <summary>
+        /// Replaces a FaceFX animation with the values from an xml file.
+        /// </summary>
+        /// <param name="control">Loaded FaceFX controls.</param>
+        /// <param name="xmlUri">Path to the XML file.</param>
+        /// <param name="chosenAnimName">In the case of multiple animations in the file, the name of the one to use.</param>
+        public static void ReplaceAnimationFromXml(FaceFXAnimSetEditorControl control, string xmlUri, string chosenAnimName = null)
+        {
+            #region xml import
+            XElement xmlDoc = XElement.Load(xmlUri);
+            List<XElement> animations = xmlDoc.Descendants("animation_groups").Descendants("animation_group").Descendants("animation").ToList();
+            XElement animationElement;
+            if (animations.Count == 0)
+            {
+                return;
+            }
+            if (animations.Count > 1)
+            {
+                List<string> animNames = animations.Select((x, i) => x.Attribute("name")?.Value ?? i.ToString()).ToList();
+                if (chosenAnimName == null) { return; }
+                animationElement = animations.Find(x => x.Attribute("name")?.Value == chosenAnimName);
+            }
+            else
+            {
+                animationElement = animations[0];
+            }
+            IEnumerable<XElement> curveNodes = animationElement.Descendants("curves").Descendants();
+            FaceFXAnimSetEditorControl.LineSection lineSec = new() { animSecs = new Dictionary<string, List<FaceFXControlPoint>>() };
+            float firstTime = float.MaxValue;
+            float lastTime = float.MinValue;
+            foreach (XElement curveNode in curveNodes)
+            {
+                string curveName = curveNode.Attribute("name")?.Value;
+                if (curveName is null)
+                {
+                    continue;
+                }
+                if (curveNode.Value is string value)
+                {
+                    float[] keys = value.Trim().Split(' ').Select(s =>
+                    {
+                        if (float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out float result))
+                        {
+                            return result;
+                        }
+                        return 0f;
+                    }).ToArray();
+                    List<FaceFXControlPoint> points = new();
+                    for (int i = 0; i + 3 < keys.Length; i += 4)
+                    {
+                        firstTime = MathF.Min(firstTime, keys[i]);
+                        lastTime = MathF.Max(firstTime, keys[i]);
+                        points.Add(new FaceFXControlPoint
+                        {
+                            time = keys[i],
+                            weight = keys[i + 1],
+                            inTangent = keys[i + 2],
+                            leaveTangent = keys[i + 3]
+                        });
+                    }
+                    lineSec.animSecs.Add(curveName, points);
+                }
+            }
+            lineSec.span = MathF.Max(0, lastTime - firstTime);
+
+            #endregion
+
+            var newPoints = new List<FaceFXControlPoint>();
+            for (int i = 0, j = 0; i < control.SelectedLine.AnimationNames.Count; i++)
+            {
+                int newNumPoints = 0;
+                string animName = control.FaceFX.Names[control.SelectedLine.AnimationNames[i]];
+                if (lineSec.animSecs.TryGetValue(animName, out List<FaceFXControlPoint> points))
+                {
+                    newPoints.AddRange(points);
+                    newNumPoints += points.Count;
+                    lineSec.animSecs.Remove(animName);
+                }
+                else
+                {
+                    for (int k = 0; k < control.SelectedLine.NumKeys[i]; k++)
+                    {
+                        newPoints.Add(control.SelectedLine.Points[j + k]);
+                        newNumPoints++;
+                    }
+                }
+                j += control.SelectedLine.NumKeys[i];
+                control.SelectedLine.NumKeys[i] = newNumPoints;
+            }
+            //add new animations
+            if (lineSec.animSecs.Count > 0)
+            {
+                foreach ((string name, List<FaceFXControlPoint> points) in lineSec.animSecs)
+                {
+                    control.SelectedLine.AnimationNames.Add(control.FaceFX.Names.FindOrAdd(name));
+                    control.SelectedLine.NumKeys.Add(points.Count);
+                    newPoints.AddRange(points);
+                }
+            }
+            control.SelectedLineEntry.Points = newPoints;
+            control.CurrentLoadedExport?.WriteBinary(control.FaceFX.Binary);
+        }
+        /// <summary>
+        /// Replaces a FaceFX animation with the values from a json file.
+        /// </summary>
+        /// <param name="control">Loaded FaceFX controls.</param>
+        /// <param name="jsonFile">Path to the json file.</param>
+        /// <param name="chosenAnimName">In the case of multiple animations in the file, the name of the one to use.</param>
+        public static void ReplaceAnimationFromJson(FaceFXAnimSetEditorControl control, string jsonFile)
+        {
+            float start = -1;
+            var lineSec = JsonConvert.DeserializeObject<FaceFXAnimSetEditorControl.LineSection>(File.ReadAllText(jsonFile));
+
+            ClearLipSyncKeys(control);
+
+            // Insert animation from json
+            var newPoints = new List<FaceFXControlPoint>();
+            for (int i = 0, j = 0; i < control.SelectedLine.AnimationNames.Count; i++)
+            {
+                int k = 0;
+                int newNumPoints = 0;
+                FaceFXControlPoint tmp;
+                for (; k < control.SelectedLine.NumKeys[i]; k++)
+                {
+                    tmp = control.SelectedLine.Points[j + k];
+                    if (tmp.time >= start)
+                    {
+                        break;
+                    }
+                    newPoints.Add(tmp);
+                    newNumPoints++;
+                }
+                string animName = control.FaceFX.Names[control.SelectedLine.AnimationNames[i]];
+                if (lineSec.animSecs.TryGetValue(animName, out List<FaceFXControlPoint> points))
+                {
+                    newPoints.AddRange(points.Select(p => { p.time += start; return p; }));
+                    newNumPoints += points.Count;
+                    lineSec.animSecs.Remove(animName);
+                }
+                for (; k < control.SelectedLine.NumKeys[i]; k++)
+                {
+                    tmp = control.SelectedLine.Points[j + k];
+                    tmp.time += lineSec.span;
+                    newPoints.Add(tmp);
+                    newNumPoints++;
+                }
+                j += control.SelectedLine.NumKeys[i];
+                control.SelectedLine.NumKeys[i] = newNumPoints;
+            }
+            //if the line we are importing from had more animations than this one, we need to add some animations
+            if (lineSec.animSecs.Count > 0)
+            {
+                foreach ((string name, List<FaceFXControlPoint> points) in lineSec.animSecs)
+                {
+                    control.SelectedLine.AnimationNames.Add(control.FaceFX.Names.FindOrAdd(name));
+                    control.SelectedLine.NumKeys.Add(points.Count);
+                    newPoints.AddRange(points.Select(p => { p.time += start; return p; }));
+                }
+            }
+
+            control.SelectedLineEntry.Points = newPoints;
+            control.CurrentLoadedExport?.WriteBinary(control.FaceFX.Binary);
+        }
+
+        /// <summary>
+        /// Update the InterpLength of the InterpData associated with the given node.
+        /// </summary>
+        /// <param name="node">Node to get the InterpData from.</param>
+        /// <param name="length">New length.</param>
+        public static void UpdateNodeLength(DialogueNodeExtended node, float length)
+        {
+            ExportEntry interpData = node.Interpdata;
+            interpData.WriteProperty(new FloatProperty(length, "InterpLength"));
+        }
+
+        /// <summary>
+        /// Change the entry/reply an reply/entry points to.
+        /// Does not write it to the conversation export.
+        /// </summary>
+        /// <param name="game">Game type.</param>
+        /// <param name="node">Node to relink.</param>
+        /// <param name="currIdx">Index of the reply/entry the node points to.</param>
+        /// <param name="targetIdx">Index of the reply/entry to target.</param>
+        /// <param name="sParphrase">String paraphrase, for entries.</param>
+        /// <param name="srParaphrase">Ref of string paraphrase, for entries.</param>
+        /// <param name="replyCategory">Type of reply, for entries.</param>
+        public static void ChangeNodeLink(MEGame game, DialogueNodeExtended node, int currIdx, int targetIdx,
+            string sParaphrase = "", int srParaphrase = 0, EReplyCategory replyCategory = EReplyCategory.REPLY_CATEGORY_DEFAULT)
+        {
+            StructProperty props = node.NodeProp;
+            if (node.IsReply)
+            {
+                ArrayProperty<IntProperty> entryList = props.GetProp<ArrayProperty<IntProperty>>("EntryList");
+                foreach (IntProperty entry in entryList)
+                {
+                    if (entry.Value == currIdx)
+                    {
+                        entry.Value = targetIdx;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                ArrayProperty<StructProperty> replyListNew = props.GetProp<ArrayProperty<StructProperty>>("ReplyListNew");
+                foreach (StructProperty reply in replyListNew)
+                {
+                    if (reply.GetProp<IntProperty>("nIndex").Value == currIdx)
+                    {
+                        PropertyCollection replyProps = reply.Properties;
+                        replyProps.AddOrReplaceProp(new StrProperty(sParaphrase, "sParaphrase"));
+                        replyProps.AddOrReplaceProp(new IntProperty(targetIdx, "nIndex"));
+                        replyProps.AddOrReplaceProp(new StringRefProperty(srParaphrase, "srParaphrase"));
+                        replyProps.AddOrReplaceProp(new EnumProperty(replyCategory.ToString(), "EReplyCategory", game, "Category"));
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add a new link to an entry/reply to the node.
+        /// Does not write it to the conversation export.
+        /// </summary>
+        /// <param name="game">Game type.</param>
+        /// <param name="node">Node to add a new entry/reply to..</param>
+        /// <param name="newIdx">Index of the reply/entry to point to.</param>
+        /// <param name="sParphrase">String paraphrase, for entries.</param>
+        /// <param name="srParaphrase">Ref of string paraphrase, for entries.</param>
+        /// <param name="replyCategory">Type of reply, for entries.</param>
+        public static void AddNodeLink(MEGame game, DialogueNodeExtended node, int newIdx,
+            string sParphrase = "", int srParaphrase = 0, EReplyCategory replyCategory = EReplyCategory.REPLY_CATEGORY_DEFAULT)
+        {
+            StructProperty props = node.NodeProp;
+            if (node.IsReply)
+            {
+                ArrayProperty<IntProperty> entryList = props.GetProp<ArrayProperty<IntProperty>>("EntryList");
+                entryList.Add(new IntProperty(newIdx));
+            }
+            else
+            {
+                ArrayProperty<StructProperty> replyListNew = props.GetProp<ArrayProperty<StructProperty>>("ReplyListNew");
+                replyListNew.Add(new StructProperty("BioDialogEntryNode", new PropertyCollection()
+                {
+                    new StrProperty(sParphrase, "sParaphrase"),
+                    new IntProperty(newIdx, "nIndex"),
+                    new StringRefProperty(srParaphrase, "srParaphrase"),
+                    new EnumProperty(replyCategory.ToString(), game, "Category")
+                }));
+            }
+        }
+
+        /// <summary>
+        /// Remove the target entry/reply from the node.
+        /// Does not write it to the conversation export.
+        /// </summary>
+        /// <param name="node">Node to operate on..</param>
+        /// <param name="targetIdx">Index of the reply/entry to remove.</param>
+        public static void RemoveNodeLink(DialogueNodeExtended node, int targetIdx)
+        {
+            StructProperty props = node.NodeProp;
+            if (node.IsReply)
+            {
+                ArrayProperty<IntProperty> entryList = props.GetProp<ArrayProperty<IntProperty>>("EntryList");
+                entryList.TryRemove(entry => entry.Value == targetIdx, out _);
+            }
+            else
+            {
+                ArrayProperty<StructProperty> replyListNew = props.GetProp<ArrayProperty<StructProperty>>("ReplyListNew");
+                replyListNew.TryRemove(reply => reply.GetProp<IntProperty>("nIndex").Value == targetIdx, out _);
+            }
+        }
+
+        /// <summary>
+        /// Writes the given Conditional or Boolean and the Parameter to the node.
+        /// Does not write it to the conversation export.
+        /// </summary>
+        /// <param name="node">Node to operate on..</param>
+        /// <param name="firesCond">True if the plot is a conditional, false if a boolean.</param>
+        /// <param name="condOrBool">Conditional or Boolean to set.</param>
+        /// <param name="condParam">Parameter to set.</param>
+        public static void WriteNodePlotCheck(DialogueNodeExtended node, bool firesCond, int condOrBool, int condParam)
+        {
+            StructProperty props = node.NodeProp;
+
+            BoolProperty bFireConditional = props.GetProp<BoolProperty>("bFireConditional");
+            bFireConditional.Value = firesCond;
+            IntProperty nConditionalFunc = props.GetProp<IntProperty>("nConditionalFunc");
+            nConditionalFunc.Value = condOrBool;
+            IntProperty nConditionalParam = props.GetProp<IntProperty>("nConditionalParam");
+            nConditionalParam.Value = condParam;
+        }
+
+        /// <summary>
+        /// Swaps the plot checks of two nodes.
+        /// Does not write it to the conversation export.
+        /// </summary>
+        /// <param name="node1">Node 1 to swap.</param>
+        /// <param name="node2">Node 2 to swap.</param>
+        public static void SwapNodesPlotChecks(DialogueNodeExtended node1, DialogueNodeExtended node2)
+        {
+            bool node1FiresConditional = node1.FiresConditional;
+            int node1CondOrBool = node1.ConditionalOrBool;
+            int node1CondParam = node1.ConditionalParam;
+            bool node2FiresConditional = node2.FiresConditional;
+            int node2CondOrBool = node2.ConditionalOrBool;
+            int node2CondParam = node2.ConditionalParam;
+
+            WriteNodePlotCheck(node1, node2FiresConditional, node2CondOrBool, node2CondParam);
+            WriteNodePlotCheck(node2, node1FiresConditional, node1CondOrBool, node1CondParam);
+        }
+
+        /// <summary>
+        /// Swaps the plot checks of two nodes.
+        /// DOES WRITE them to the conversation export.
+        /// </summary>
+        /// <param name="node1">Node 1 to swap.</param>
+        /// <param name="node2">Node 2 to swap.</param>
+        public static void SwapAndWriteNodesPlotChecks(ExportEntry exp, DialogueNodeExtended node1, DialogueNodeExtended node2)
+        {
+            SwapNodesPlotChecks(node1, node2);
+            WriteNodes(exp, node1, node2);
+        }
+
+        /// <summary>
+        /// Swaps the order of the first two entries or replies of the given node
+        /// Does not write it to the conversation export.
+        /// </summary>
+        /// <param name="conversation">Conversation to find nodes in.</param>
+        /// <param name="node">Node to swap nodes of.</param>
+        /// <returns>The swapped nodes.</returns>
+        public static (DialogueNodeExtended, DialogueNodeExtended) SwapFirstTwoNodes(ConversationExtended conversation, DialogueNodeExtended node)
+        {
+            DialogueNodeExtended node1;
+            DialogueNodeExtended node2;
+
+            StructProperty props = node.NodeProp;
+            if (node.IsReply)
+            {
+                ArrayProperty<IntProperty> entryList = props.GetProp<ArrayProperty<IntProperty>>("EntryList");
+                (entryList[1], entryList[0]) = (entryList[0], entryList[1]);
+                node1 = GetNodeByIndex(conversation, entryList[0], false);
+                node2 = GetNodeByIndex(conversation, entryList[1], false);
+            }
+            else
+            {
+                ArrayProperty<StructProperty> replyList = props.GetProp<ArrayProperty<StructProperty>>("ReplyListNew");
+                (replyList[1], replyList[0]) = (replyList[0], replyList[1]);
+                node1 = GetNodeByIndex(conversation, replyList[0].GetProp<IntProperty>("nIndex").Value, true);
+                node2 = GetNodeByIndex(conversation, replyList[1].GetProp<IntProperty>("nIndex").Value, true);
+            }
+
+            return (node1, node2);
+        }
+
+        /// <summary>
+        /// Swaps the first two nodes that the node links to, and swaps their plot values.
+        /// DOES WRITE the node and the first two nodes to the exp.
+        /// </summary>
+        /// <param name="exp">Conversation export to write to.</param>
+        /// <param name="conv">Loaded conversation to operate from.</param>
+        /// <param name="node">Source node to get children from.</param>
+        public static void SwapAndWriteFirstTwoNodesAndPlots(ExportEntry exp, ConversationExtended conv, DialogueNodeExtended node)
+        {
+            (DialogueNodeExtended node1, DialogueNodeExtended node2) = SwapFirstTwoNodes(conv, node);
+            SwapNodesPlotChecks(node1, node2);
+            WriteNodes(exp, node, node1, node2);
+        }
+
+        /// <summary>
+        /// Swaps the first two nodes that the node links to.
+        /// DOES WRITE the node and the first two nodes to the exp.
+        /// </summary>
+        /// <param name="exp">Conversation export to write to.</param>
+        /// <param name="conv">Loaded conversation to operate from.</param>
+        /// <param name="node">Source node to get children from.</param>
+        public static void SwapAndWriteFirstTwoNodes(ExportEntry exp, ConversationExtended conv, DialogueNodeExtended node)
+        {
+            SwapFirstTwoNodes(conv, node);
+            WriteNode(node, exp);
+        }
+
+        /// <summary>
+        /// Swaps the first two nodes that the nodes link to, and swaps their plot values.
+        /// DOES WRITE the nodes and the first two nodes to the exp.
+        /// </summary>
+        /// <param name="exp">Conversation export to write to.</param>
+        /// <param name="conv">Loaded conversation to operate from.</param>
+        /// <param name="node">Source node to get children from.</param>
+        public static void BatchSwapAndWriteFirstTwoNodesAndPlots(ExportEntry exp, ConversationExtended conv, params DialogueNodeExtended[] nodes)
+        {
+            BatchSwapAndWriteFirstTwoNodesAndPlots(exp, conv, nodes);
+        }
+        public static void BatchSwapAndWriteFirstTwoNodesAndPlots(ExportEntry exp, ConversationExtended conv, IEnumerable<DialogueNodeExtended> nodes)
+        {
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                SwapAndWriteFirstTwoNodesAndPlots(exp, conv, node);
+            }
+        }
+
+        /// <summary>
+        /// Swaps the first two nodes that the nodes link to.
+        /// DOES WRITE the nodes and the first two nodes to the exp.
+        /// </summary>
+        /// <param name="exp">Conversation export to write to.</param>
+        /// <param name="conv">Loaded conversation to operate from.</param>
+        /// <param name="node">Source node to get children from.</param>
+        public static void BatchSwapAndWriteFirstTwoNodes(ExportEntry exp, ConversationExtended conv, params DialogueNodeExtended[] nodes)
+        {
+            BatchSwapAndWriteFirstTwoNodes(exp, conv, nodes);
+        }
+        public static void BatchSwapAndWriteFirstTwoNodes(ExportEntry exp, ConversationExtended conv, IEnumerable<DialogueNodeExtended> nodes)
+        {
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                SwapAndWriteFirstTwoNodes(exp, conv, node);
+            }
+        }
+
+        /// <summary>
+        /// Try get the first Interp referencing the InterpData.
+        /// </summary>
+        /// <param name="interpData">InterpData to search on.</param>
+        /// <param name="interp">Referencing interp.</param>
+        /// <returns>Whether the Interp was found or not.</returns>
+        public static bool TryGetInterp(ExportEntry interpData, out ExportEntry interp)
+        {
+            interp = null;
+
+            Dictionary<IEntry, List<string>> refs = interpData.GetEntriesThatReferenceThisOne();
+
+            if (refs.Count == 0) { return false; }
+
+            IEntry entry = null;
+            foreach (IEntry e in refs.Keys)
+            {
+                if (e.ClassName == "SeqAct_Interp")
+                {
+                    entry = e;
+                    break;
+                }
+            }
+
+            interp = (ExportEntry)entry;
+            return true;
+        }
+
+        /// <summary>
+        /// Filter the nodes, by the filter condition, to get only those that have valid audio information.
+        /// </summary>
+        /// <param name="nodes">Nodes to filter.</param>
+        /// <param name="filter">Filter to apply to the audio nodes.</param>
+        /// <param name="usedIDs">ExportIDs that exist in all the nodes. Useful for linking IDs or generating new ones.</param>
+        /// <returns>Filtered nodes.</returns>
+        public static List<DialogueNodeExtended> FilterAudioNodes(ObservableCollectionExtended<DialogueNodeExtended> nodes,
+            Func<DialogueNodeExtended, bool> filter,
+            HashSet<int> usedIDs = null)
+        {
+            if (nodes == null) { return null; }
+
+            List<DialogueNodeExtended> filteredNodes = new();
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                if (node.ExportID > 0 && usedIDs != null) { usedIDs.Add(node.ExportID); }
+
+                if (IsAudioNode(node) && filter(node)) { filteredNodes.Add(node); }
+            }
+
+            return filteredNodes;
+        }
+
+        /// <summary>
+        /// Check if the given node is a valid audio node.
+        /// CONDITION: Has FaceFX. FaceFX matches LineRef. LineRef is not -1. Reply type is REPLY_STANDARD.
+        /// </summary>
+        /// <param name="node">Node to check.</param>
+        /// <returns>Whether it's an audio node or not.</returns>
+        public static bool IsAudioNode(DialogueNodeExtended node)
+        {
+            return IsAudioNode(node, out string errMsg);
+        }
+
+        /// <summary>
+        /// Check if the given node is a valid audio node.
+        /// CONDITION: Has FaceFX. FaceFX matches LineRef. LineRef is not -1. Reply type is REPLY_STANDARD.
+        /// </summary>
+        /// <param name="node">Node to check.</param>
+        /// <param name="errMsg">Error message.</param>
+        /// <returns>Whether it's an audio node or not.</returns>
+        public static bool IsAudioNode(DialogueNodeExtended node, out string errMsg)
+        {
+            errMsg = "";
+            // Check that there's at least one FaceFX and store its strRef
+            string faceFX = node.FaceFX_Female ?? (node.FaceFX_Male ?? "");
+
+            // Validate that the node is meant to have data (not autocontinues or dialogend)
+            // and that has proper audio data (strRef matches the FaceFX)
+            if (string.IsNullOrEmpty(faceFX) || !faceFX.Contains($"{node.LineStrRef}") || node.LineStrRef == -1)
+            {
+                errMsg = $"Node {(node.IsReply ? "R" : "E")}{node.NodeCount} does not contain valid audio data. Check it contains a LineStrRef, and that its FaceFX exists and points to it.";
+                return false;
+            }
+            if (node.ReplyType != EReplyTypes.REPLY_STANDARD)
+            {
+                errMsg = $"Node {(node.IsReply ? "R" : "E")}{node.NodeCount}'s type is not REPLY_STANDARD.";
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Get the StrRefID of the VOElements track and the track itself of an InterpData, if they exist.
+        /// </summary>
+        /// <param name="interpData">InterpData to find the value on.</param>
+        /// <param name="VOTrack">VOElementes track, if it exists.</param>
+        /// <returns>StrRefID, if it exists.</returns>
+        public static int GetVOStrRefID(ExportEntry interpData, out ExportEntry VOTrack)
+        {
+            VOTrack = null;
+            if (!MatineeHelper.TryGetInterpGroup(interpData, "Conversation", out ExportEntry interpGroup))
+            {
+                return 0;
+            }
+
+            if (!MatineeHelper.TryGetInterpTrack(interpGroup, "BioEvtSysTrackVOElements", out ExportEntry interpTrack))
+            {
+                return 0;
+            }
+
+            IntProperty m_nStrRefID = interpTrack.GetProperty<IntProperty>("m_nStrRefID");
+            if (m_nStrRefID == null)
+            {
+                return 0;
+            }
+
+            VOTrack = interpTrack;
+            return m_nStrRefID.Value;
+        }
+
+        /// <summary>
+        /// Update the StrRefID of the VOElements track of the InterpData. Creates any missing element.
+        /// </summary>
+        /// <param name="interpData">InterpData to update the value on.</param>
+        /// <param name="strRefID">StringRefID to set.</param>
+        public static void UpdateInterpDataStrRefID(ExportEntry interpData, int strRefID, ExportEntry VOElements = null)
+        {
+            if (VOElements == null)
+            {
+                if (!MatineeHelper.TryGetInterpGroup(interpData, "Conversation", out ExportEntry interpGroup))
+                {
+                    interpGroup = MatineeHelper.AddNewGroupToInterpData(interpData, "Conversation");
+                }
+
+                if (!MatineeHelper.TryGetInterpTrack(interpGroup, "BioEvtSysTrackVOElements", out VOElements))
+                {
+                    VOElements = MatineeHelper.AddNewTrackToGroup(interpGroup, "BioEvtSysTrackVOElements");
+                }
+            }
+
+            PropertyCollection props = VOElements.GetProperties();
+            props.AddOrReplaceProp(new IntProperty(strRefID, "m_nStrRefID"));
+            AddDefaultTrackKey(VOElements, false, 0, props);
+            VOElements.WriteProperties(props);
+        }
+
+        /// <summary>
+        /// Add a default key to the TrackKeys prop of the interpTrack, if it doesn't contain one, creating the property if necessary,
+        /// and writing the props if requested.
+        /// </summary>
+        /// <param name="interpTrack">Track to add the key to.</param>
+        /// <param name="writeProps">Whether to write the props or not. Useful to have control whether the caller or the callee writes and avoid redundant writes.</param>
+        /// <param name="time">Time to insert the key at.</param>
+        /// <param name="props">Props containing the trackKeys, or to which write them.</param>
+        /// <returns>Updated property collection.</returns>
+        public static PropertyCollection AddDefaultTrackKey(ExportEntry interpTrack, bool writeProps, int time = 0, PropertyCollection props = null)
+        {
+            if (props == null) { props = interpTrack.GetProperties(); }
+            ArrayProperty<StructProperty> m_aTrackKeys = props.GetProp<ArrayProperty<StructProperty>>("m_aTrackKeys")
+                ?? new ArrayProperty<StructProperty>("m_aTrackKeys");
+
+            if (!m_aTrackKeys.Any())
+            {
+                // Add the key to the track
+                m_aTrackKeys.Add(new StructProperty("BioTrackKey",
+                    new PropertyCollection()
+                    {
+                        new NameProperty("None", "KeyName"),
+                        new FloatProperty(time, "fTime")
+                    },
+                    "BioTrackKey"));
+
+                props.AddOrReplaceProp(m_aTrackKeys);
+            }
+            if (writeProps) { interpTrack.WriteProperties(props); }
+
+            return props;
+        }
+
+        /// <summary>
+        /// Generate an ObjComment array containing a single comment based on the given line,
+        /// concatenating the line at 29 characters and adding an ellipsis at the end
+        /// </summary>
+        /// <param name="line">Line to use to generate the comment.</param>
+        /// <returns>Generated ObjComment array.</returns>
+        public static ArrayProperty<StrProperty> GenerateObjComment(string line)
+        {
+            line = line.Trim('\"');
+            return new("m_aObjComment")
+            {
+                new StrProperty(line == "No Data" ? "" : line.Length <= 32 ? line : $"{line.AsSpan(0, 29)}...")
+            };
+        }
+    }
+
+    /// <summary>
+    /// Represents audio information of a TLK line.
+    /// </summary>
+    public class LineAudioInfo
+    {
+        public string Filename_F
+        {
+            get; set;
+        }
+        public string Filename_M
+        {
+            get; set;
+        }
+        public int SizeOnDisk_F
+        {
+            get; set;
+        }
+        public int SizeOnDisk_M
+        {
+            get; set;
+        }
+        public string OffsetInFile_F
+        {
+            get; set;
+        }
+        public string OffsetInFile_M
+        {
+            get; set;
+        }
+        public string XMLUri_F
+        {
+            get; set;
+        }
+        public string XMLUri_M
+        {
+            get; set;
+        }
+        public string AnimationName_F
+        {
+            get; set;
+        }
+        public string AnimationName_M
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Represents audio information of a TLK line.
+        /// </summary>
+        /// <param name="filename_f">The afc filename the audio is on for the female line.</param>
+        /// <param name="filename_m">The afc filename the audio is on for the male line.</param>
+        /// <param name="sizeOnDisk_f">The binary size on disk for the female line.</param>
+        /// <param name="sizeOnDisk_m">The binary size on disk for the male line.</param>
+        /// <param name="offsetInFile_f">The binary offset in file as hex for the female line.</param>
+        /// <param name="offsetInFile_m">The binary offset in file as hex for the male line.</param>
+        /// <param name="xmlUri_f">Path to the XML file containing the face animations for the female line, optional.</param>
+        /// <param name="xmlUri_m">Path to the XML file containing the face animations for the male line, optional.</param>
+        /// <param name="animationName_f">Animation to select from the female XML file, optional.</param>
+        /// <param name="animationName_m">Animation to select from the male XML file, optional.</param>
+        public LineAudioInfo(string filename_f, string filename_m, int sizeOnDisk_f, int sizeOnDisk_m, string offsetInFile_f, string offsetInFile_m,
+            string xmlUri_f = "", string xmlUri_m = "", string animationName_f = "", string animationName_m = "")
+        {
+            Filename_F = filename_f;
+            Filename_M = filename_m;
+            SizeOnDisk_F = sizeOnDisk_f;
+            SizeOnDisk_M = sizeOnDisk_m;
+            OffsetInFile_F = offsetInFile_f;
+            OffsetInFile_M = offsetInFile_m;
+            XMLUri_F = xmlUri_f;
+            XMLUri_M = xmlUri_m;
+            AnimationName_F = animationName_f;
+            AnimationName_M = animationName_m;
+        }
+    }
+}

--- a/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/InterpAutomations.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/InterpAutomations.cs
@@ -1,0 +1,32 @@
+﻿using LegendaryExplorer.DialogueEditor.DialogueEditorExperiments;
+using LegendaryExplorer.Tools.TlkManagerNS;
+using LegendaryExplorer.UserControls.ExportLoaderControls;
+using LegendaryExplorerCore.Dialogue;
+using LegendaryExplorerCore.Gammtek.Extensions.Collections.Generic;
+using LegendaryExplorerCore.Helpers;
+using LegendaryExplorerCore.Kismet;
+using LegendaryExplorerCore.Matinee;
+using LegendaryExplorerCore.Misc;
+using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Packages.CloningImportingAndRelinking;
+using LegendaryExplorerCore.Unreal;
+using LegendaryExplorerCore.Unreal.BinaryConverters;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Xml.Linq;
+
+using static LegendaryExplorer.Misc.ExperimentsTools.SharedMethods;
+
+namespace LegendaryExplorer.Misc.ExperimentsTools
+{
+    public static class InterpAutomations
+    {
+    }
+}

--- a/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/PackageAutomations.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/PackageAutomations.cs
@@ -1,0 +1,117 @@
+﻿using LegendaryExplorer.DialogueEditor.DialogueEditorExperiments;
+using LegendaryExplorer.Tools.TlkManagerNS;
+using LegendaryExplorer.UserControls.ExportLoaderControls;
+using LegendaryExplorerCore.Dialogue;
+using LegendaryExplorerCore.Gammtek.Extensions.Collections.Generic;
+using LegendaryExplorerCore.Helpers;
+using LegendaryExplorerCore.Kismet;
+using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Packages.CloningImportingAndRelinking;
+using LegendaryExplorerCore.Unreal;
+using LegendaryExplorerCore.Unreal.BinaryConverters;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Xml.Linq;
+
+using static LegendaryExplorer.Misc.ExperimentsTools.SharedMethods;
+
+namespace LegendaryExplorer.Misc.ExperimentsTools
+{
+    public static class PackageAutomations
+    {
+        /// <summary>
+        /// Create a LevelStreamingKismet with the filename in the file.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="filename">Name of file to stream.</param>
+        /// <param name="inPersistentlevel">Whether to add it in the PersistentLevel or in TheWorld.</param>
+        public static ExportEntry AddStreamingKismet(IMEPackage pcc, string filename, bool inPersistentlevel = false)
+        {
+            ExportEntry kismet = CreateExport(
+                pcc, pcc.GetNextIndexedName("LevelStreamingKismet"), "LevelStreamingKismet",
+                inPersistentlevel ? GetPersistentLevel(pcc) : GetTheWorld(pcc),
+                new PropertyCollection() { new NameProperty(filename, "PackageName") }
+                );
+
+            RebuildStreamingLevels(pcc);
+
+            return kismet;
+        }
+
+        /// <summary>
+        /// Set the loading and streaming of the given file name in all the BioTriggerStreams where the conditional file is present.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="filename">Name of file to stream.</param>
+        /// <param name="conditionalFile"></param>
+        public static void StreamFile(IMEPackage pcc, string filename, string conditionalFile)
+        {
+            List<ExportEntry> triggerStreams = GetExports(pcc, "BioTriggerStream");
+
+            foreach (ExportEntry triggerStream in triggerStreams)
+            {
+                ArrayProperty<StructProperty> streamingLevels = triggerStream.GetProperty<ArrayProperty<StructProperty>>("StreamingStates");
+                if (streamingLevels == null) { continue; }
+
+                // Iterate through all the streaming levels
+                foreach (StructProperty streamingLevel in streamingLevels)
+                {
+                    ArrayProperty<NameProperty> visibleChunkNames = streamingLevel.GetProp<ArrayProperty<NameProperty>>("VisibleChunkNames");
+                    ArrayProperty<NameProperty> loadChunkNames = streamingLevel.GetProp<ArrayProperty<NameProperty>>("LoadChunkNames");
+                    ArrayProperty<NameProperty> reference = null;
+
+                    // Check if the conditional file is in the visible chunks
+                    foreach (NameProperty visibleChunkName in visibleChunkNames)
+                    {
+                        if (StringExtensions.CaseInsensitiveEquals(visibleChunkName.Value, conditionalFile))
+                        {
+                            reference = visibleChunkNames;
+                            break;
+                        }
+                    }
+                    // If the conditional file was not in the visible chunks, check in the load chunks
+                    if (reference == null)
+                    {
+                        foreach (NameProperty loadChunkName in loadChunkNames)
+                        {
+                            if (StringExtensions.CaseInsensitiveEquals(loadChunkName.Value, conditionalFile))
+                            {
+                                reference = loadChunkNames;
+                                break;
+                            }
+                        }
+                    }
+
+                    // If neither contained the conditional file, skip this level
+                    if (reference == null) { continue; }
+
+                    // Add the filename
+                    reference.Add(new NameProperty(filename));
+                }
+
+                triggerStream.WriteProperty(streamingLevels);
+            }
+        }
+
+        /// <summary>
+        /// Replace the old name with the new name, if the old one exists.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="oldName">Name to edit.</param>
+        /// <param name="newName">Name to edit in.</param>
+        /// <exception cref="Exception">If name not found.</exception>
+        public static void EditName(IMEPackage pcc, string oldName, string newName)
+        {
+            int oldIdx = pcc.findName(oldName);
+            if (oldIdx < 0) { throw new Exception(oldName); }
+            pcc.replaceName(oldIdx, newName);
+        }
+    }
+}

--- a/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/SequenceAutomations.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/SequenceAutomations.cs
@@ -1,0 +1,223 @@
+﻿using LegendaryExplorer.DialogueEditor.DialogueEditorExperiments;
+using LegendaryExplorer.Tools.TlkManagerNS;
+using LegendaryExplorer.UserControls.ExportLoaderControls;
+using LegendaryExplorerCore.Dialogue;
+using LegendaryExplorerCore.Gammtek.Extensions.Collections.Generic;
+using LegendaryExplorerCore.Helpers;
+using LegendaryExplorerCore.Kismet;
+using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Packages.CloningImportingAndRelinking;
+using LegendaryExplorerCore.Unreal;
+using LegendaryExplorerCore.Unreal.BinaryConverters;
+using LegendaryExplorerCore.Unreal.ObjectInfo;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Xml.Linq;
+
+using static LegendaryExplorer.Misc.ExperimentsTools.SharedMethods;
+
+namespace LegendaryExplorer.Misc.ExperimentsTools
+{
+    public static class SequenceAutomations
+    {
+        /// <summary>
+        /// Add a streaming handshake to the given sequence, which runs after being triggered by the input, and continues to the output.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="sequence">Sequence to add the handshake to.</param>
+        /// <param name="outEvtName">Name of the event to activate.</param>
+        /// <param name="inEvtName">Name of the activated event to react to.</param>
+        /// <returns>(outEvent, gate) The event to activate and the output gate.</returns>
+        public static (ExportEntry, ExportEntry) AddEventHandshake(IMEPackage pcc, ExportEntry sequence, string outEvtName, string inEvtName)
+        {
+            // Create the handshake objects
+            ExportEntry outEvent = CreateSequenceObjectWithProps(pcc, "SeqAct_ActivateRemoteEvent", new() { new NameProperty(outEvtName, "EventName") });
+            ExportEntry inEvent = CreateSequenceObjectWithProps(pcc, "SeqEvent_RemoteEvent", new() { new NameProperty(inEvtName, "EventName") });
+            ExportEntry gate = CreateSequenceObjectWithProps(pcc, "SeqAct_Gate", new() { new BoolProperty(false, "bOpen") });
+
+            KismetHelper.AddObjectsToSequence(sequence, false, new[] { outEvent, inEvent, gate });
+
+            // Connect the handshake objects
+            KismetHelper.CreateOutputLink(outEvent, "Out", gate, 1); // outEvent.Out to gate.Open
+            KismetHelper.CreateOutputLink(gate, "Out", gate, 2); // gate.Out to gate.Close
+            KismetHelper.CreateOutputLink(inEvent, "Out", gate, 0); // inEvent.Out to gate.In
+
+            return (outEvent, gate);
+        }
+
+        /// <summary>
+        /// Inserts a remote event handshake, connected between the source seqObject and all of the objets its outputs link to.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="sequence">Sequence to operate on.</param>
+        /// <param name="seqObj">Object to insert the handshake after.</param>
+        /// <param name="outEvtName">Name of the event to activate.</param>
+        /// <param name="inEvtName">Name of the activated event to react to.</param>
+        /// <param name="skipOutIdxs">Output indexes to skip. Specially used when wanting to manually connect failed outputs of conversations.</param>
+        /// <returns>(outEvent, gate) The event to activate and the output gate.</returns>
+        public static (ExportEntry, ExportEntry) InsertEventHandshake(IMEPackage pcc, ExportEntry sequence, ExportEntry seqObj, string outEvtName, string inEvtName, int[] skipOutIdxs = null)
+        {
+            (ExportEntry outEvent, ExportEntry gate) = AddEventHandshake(pcc, sequence, outEvtName, inEvtName); // Craete the event handshake
+
+            // Connect the output of the gate to all the links of the seqObj
+            List<List<OutputLink>> outboundLinks = KismetHelper.GetOutputLinksOfNode(seqObj);
+            List<(int, int)> linked = new();
+            for (int i = 0; i < outboundLinks.Count; i++)
+            {
+                if (skipOutIdxs != null && skipOutIdxs.Contains(i)) { continue; }
+
+                foreach (OutputLink link in outboundLinks[i])
+                {
+                    if (linked.Exists(el => link.LinkedOp.UIndex == el.Item1 && link.InputLinkIdx == el.Item2)) { continue; }
+                    KismetHelper.CreateOutputLink(gate, "Out", (ExportEntry)link.LinkedOp, link.InputLinkIdx);
+                    linked.Add((link.LinkedOp.UIndex, link.InputLinkIdx));
+                }
+            }
+
+            // Remove the current links of the objet, and link it to the handshake.
+            // We do this to ensure that when we skip the object later, the inputs are linked to the handshake only,
+            // instead of other things, as the handshake takes care of that.
+            KismetHelper.RemoveOutputLinks(seqObj);
+            KismetHelper.CreateOutputLink(seqObj, "Out", outEvent, 0);
+
+            return (outEvent, gate);
+        }
+
+        /// <summary>
+        /// Replaces an object in a sequence with a remote event handshake, relinking its input and output links.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="sequence">Sequence to operate on.</param>
+        /// <param name="seqObj">Object to replace.</param>
+        /// <param name="outEvtName">Name of the event to activate.</param>
+        /// <param name="inEvtName">Name of the activated event to react to.</param>
+        /// <param name="skipOutIdxs">Output indexes to skip. Specially used when wanting to manually connect failed outputs of conversations.</param>
+        /// <returns>(outEvent, gate) The event to activate and the output gate.</returns>
+        public static (ExportEntry, ExportEntry) ReplaceObjectWithEventHandshake(IMEPackage pcc, ExportEntry sequence, ExportEntry seqObj, string outEvtName, string inEvtName, int[] skipOutIdxs = null)
+        {
+            (ExportEntry outEvent, ExportEntry gate) = AddEventHandshake(pcc, sequence, outEvtName, inEvtName); // Craete the event handshake
+
+            // Connect the output of the gate to all the links of the seqObj
+            List<List<OutputLink>> outboundLinks = KismetHelper.GetOutputLinksOfNode(seqObj);
+            List<(int, int)> linked = new();
+            for (int i = 0; i < outboundLinks.Count; i++)
+            {
+                if (skipOutIdxs != null && skipOutIdxs.Contains(i)) { continue; }
+
+                foreach (OutputLink link in outboundLinks[i])
+                {
+                    if (linked.Exists(el => link.LinkedOp.UIndex == el.Item1 && link.InputLinkIdx == el.Item2)) { continue; }
+                    KismetHelper.CreateOutputLink(gate, "Out", (ExportEntry)link.LinkedOp, link.InputLinkIdx);
+                    linked.Add((link.LinkedOp.UIndex, link.InputLinkIdx));
+                }
+            }
+
+            // Remove the current links of the objet, and link it to the handshake.
+            // We do this to ensure that when we skip the object later, the inputs are linked to the handshake only,
+            // instead of other things, as the handshake takes care of that.
+            KismetHelper.RemoveOutputLinks(seqObj);
+            KismetHelper.CreateOutputLink(seqObj, "Out", outEvent, 0);
+
+            // Skip the element so the inputs point to our handshake
+            KismetHelper.SkipSequenceElement(seqObj, null, 0);
+
+            // Skipping DOES NOT remove output links, so we clean the skipped object
+            KismetHelper.RemoveOutputLinks(seqObj);
+            KismetHelper.RemoveVariableLinks(seqObj);
+
+            return (outEvent, gate);
+        }
+
+        /// <summary>
+        /// Swaps the output links of a PMCheckState.
+        /// </summary>
+        /// <param name="obj">PMCheckState object.</param>
+        public static void SwapCheckStateOutputs(ExportEntry obj)
+        {
+            List<List<OutputLink>> outLinks = KismetHelper.GetOutputLinksOfNode(obj);
+            List<OutputLink> tempLinks = outLinks[0];
+            outLinks[0] = outLinks[1];
+            outLinks[1] = tempLinks;
+            KismetHelper.WriteOutputLinksToNode(obj, outLinks);
+        }
+
+        /// <summary>
+        /// Skips a sequence element, and removes its output and variable links to completely disconnect it.
+        /// </summary>
+        /// <param name="seqObj">The sequence object to skip</param>
+        /// <param name="outboundLinkName">The name of the outbound link that should be attached to the preceding entry element, must have either this or the next argument</param>
+        /// <param name="outboundLinkIdx">The 0-indexed outbound link that should be attached the preceding entry element, as if this one had fired that link.</param>
+        public static void SkipAndCleanSequenceElement(ExportEntry seqObj, string outboundLinkName = null, int outboundLinkIdx = -1)
+        {
+            KismetHelper.SkipSequenceElement(seqObj, null, 0);
+            KismetHelper.RemoveOutputLinks(seqObj);
+            KismetHelper.RemoveVariableLinks(seqObj);
+        }
+
+        /// <summary>
+        /// Creates a sequence object with default props plus the ones passed as customProps;
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="className">Name of the object's class.</param>
+        /// <param name="customProps">Props to add to the object.</param>
+        /// <returns></returns>
+        public static ExportEntry CreateSequenceObjectWithProps(IMEPackage pcc, string className, PropertyCollection customProps)
+        {
+            ExportEntry seqObj = SequenceObjectCreator.CreateSequenceObject(pcc, className);
+            PropertyCollection props = SequenceObjectCreator.GetSequenceObjectDefaults(pcc, className, pcc.Game);
+
+            foreach (Property prop in customProps) { props.AddOrReplaceProp(prop); }
+
+            seqObj.WriteProperties(props);
+
+            return seqObj;
+        }
+
+        /// <summary>
+        /// Create a var link with custom properties.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="name">LinkDesc.</param>
+        /// <returns>The varLink StructProperty.</returns>
+        public static StructProperty CreateVarLink(IMEPackage pcc, string name)
+        {
+            PropertyCollection props = GlobalUnrealObjectInfo.getDefaultStructValue(pcc.Game, "SeqVarLink", true);
+
+            int minVars = name == "Anchor" ? 1 : 0;
+            int maxVars = name == "Anchor" ? 1 : 255;
+
+            props.AddOrReplaceProp(new StrProperty(name, "LinkDesc"));
+            int index = pcc.FindImport("Engine.SeqVar_Object").UIndex;
+            props.AddOrReplaceProp(new ObjectProperty(index, "ExpectedType"));
+            props.AddOrReplaceProp(new IntProperty(minVars, "MinVars"));
+            props.AddOrReplaceProp(new IntProperty(maxVars, "MaxVars"));
+            return new StructProperty("SeqVarLink", props);
+        }
+
+        // From SequenceEditorWPF.xaml.cs
+        /// <summary>
+        /// Clones the old object and add it to the given sequence..
+        /// </summary>
+        /// <param name="old">Object to clone.</param>
+        /// <param name="sequence">Sequence to add the object to.</param>
+        /// <param name="topLevel"></param>
+        /// <param name="incrementIndex"></param>
+        /// <returns>Cloned object.</returns>
+        public static ExportEntry CloneObject(ExportEntry old, ExportEntry sequence, bool topLevel = true, bool incrementIndex = true)
+        {
+            //SeqVar_External needs to have the same index to work properly
+            ExportEntry exp = EntryCloner.CloneEntry(old, incrementIndex: incrementIndex && old.ClassName != "SeqVar_External");
+
+            KismetHelper.AddObjectToSequence(exp, sequence, topLevel);
+            // cloneSequence(exp);
+            return exp;
+        }
+    }
+}

--- a/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/SharedMethods.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Misc/ExperimentsTools/SharedMethods.cs
@@ -1,0 +1,365 @@
+﻿using LegendaryExplorer.Dialogs;
+using LegendaryExplorerCore.Helpers;
+using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Packages.CloningImportingAndRelinking;
+using LegendaryExplorerCore.Unreal;
+using LegendaryExplorerCore.Unreal.BinaryConverters;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace LegendaryExplorer.Misc.ExperimentsTools
+{
+    public static class SharedMethods
+    {
+        #region Exkywor's Experiments Shared Methods
+        /// <summary>
+        /// Shows an error dialog with the given message.
+        /// </summary>
+        /// <param name="errMsg">Message to display.</param>
+        public static void ShowError(string errMsg) => MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
+        /// <summary>
+        /// Shows an success dialog with the given message.
+        /// </summary>
+        /// <param name="msg">Message to display.</param>
+        public static void ShowSuccess(string msg) => MessageBox.Show(msg, "Success", MessageBoxButton.OK);
+
+        /// <summary>
+        /// Generate a default ExpressionGUID.
+        /// </summary>
+        /// <returns>ExpressionGUID StructProperty</returns>
+        public static StructProperty GenerateExpressionGUID()
+        {
+            PropertyCollection props = new PropertyCollection();
+            props.Add(new IntProperty(0, "A"));
+            props.Add(new IntProperty(0, "B"));
+            props.Add(new IntProperty(0, "C"));
+            props.Add(new IntProperty(0, "D"));
+
+            return new StructProperty("Guid", props, "ExpressionGUID", true);
+        }
+
+        /// <summary>
+        /// Cast the entry to ExportEntry, or resolve it if it's an ImportEntry.
+        /// </summary>
+        /// <param name="entry">Entry to resolve.</param>
+        /// <returns>Resulting ExportEntry.</returns>
+        public static ExportEntry ResolveEntryToExport(IEntry entry)
+        {
+            if (entry is ImportEntry import) { return EntryImporter.ResolveImport(import); }
+            else { return (ExportEntry)entry; }
+        }
+
+        /// <summary>
+        /// By SirCxyrtyx.
+        /// </summary>
+        /// <param name="pcc"></param>
+        /// <param name="name"></param>
+        /// <param name="className"></param>
+        /// <param name="parent"></param>
+        /// <param name="properties"></param>
+        /// <param name="binary"></param>
+        /// <param name="prePropBinary"></param>
+        /// <param name="super"></param>
+        /// <param name="archetype"></param>
+        /// <returns>New ExportEntry</returns>
+        public static ExportEntry CreateExport(IMEPackage pcc, NameReference name, string className, IEntry parent, PropertyCollection properties = null, ObjectBinary binary = null, byte[] prePropBinary = null, IEntry super = null, IEntry archetype = null)
+        {
+            IEntry classEntry = className.CaseInsensitiveEquals("Class") ? null : EntryImporter.EnsureClassIsInFile(pcc, className, new RelinkerOptionsPackage());
+
+            var exp = new ExportEntry(pcc, parent, name, prePropBinary, properties, binary, binary is UClass)
+            {
+                Class = classEntry,
+                SuperClass = super,
+                Archetype = archetype
+            };
+            pcc.AddExport(exp);
+            return exp;
+        }
+
+        /// <summary>
+        /// Adds the stack to the binary of the given export.
+        /// </summary>
+        /// <param name="export">Export to write to</param>
+        public static void AddStack(ExportEntry export)
+        {
+            if (export.HasStack)
+            {
+                return;
+            }
+            var ms = new MemoryStream();
+            ms.WriteInt32(export.Class.UIndex);
+            if (export.Game != MEGame.UDK)
+            {
+                ms.WriteInt32(export.Class.UIndex);
+            }
+            ms.WriteInt64(-1);
+            if (export.Game >= MEGame.ME3)
+            {
+                ms.WriteInt16(0);
+            }
+            else
+            {
+                ms.WriteInt32(0);
+            }
+            ms.WriteInt32(0);
+            ms.WriteInt32(-1);
+            ms.WriteInt32(export.NetIndex);
+            ms.Write(export.DataReadOnly[export.GetPropertyStart()..]);
+            export.ObjectFlags |= UnrealFlags.EObjectFlags.HasStack;
+            export.Data = ms.ToArray();
+        }
+
+        /// <summary>
+        /// Gets the common prefix of two strings. Assumes both only difer at the end.
+        /// </summary>
+        /// <param name="s1">First string.</param>
+        /// <param name="s2">Second string.</param>
+        /// <returns>Union of input strings.</returns>
+        public static string GetCommonPrefix(string s1, string s2)
+        {
+            if (s1.Length == 0 || s2.Length == 0 || char.ToLower(s1[0]) != char.ToLower(s2[0]))
+            {
+                return "";
+            }
+
+            for (int i = 1; i < s1.Length && i < s2.Length; i++)
+            {
+                if (char.ToLower(s1[i]) != char.ToLower(s2[i]))
+                {
+                    return s1[..i];
+                }
+            }
+
+            return s1.Length < s2.Length ? s1 : s2;
+        }
+
+        public static IEntry GetTheWorld(IMEPackage pcc) => pcc.FindEntry("TheWorld");
+        public static IEntry GetPersistentLevel(IMEPackage pcc) => pcc.FindEntry("TheWorld.PersistentLevel");
+        public static List<ExportEntry> GetExports(IMEPackage pcc, string className) =>
+            pcc.Exports.Where(export => export.ClassName.Equals(className)).ToList();
+
+        public static void RebuildStreamingLevels(IMEPackage pcc)
+        {
+            try
+            {
+                var levelStreamingKismets = new List<ExportEntry>();
+                ExportEntry bioworldinfo = null;
+                foreach (ExportEntry exp in pcc.Exports)
+                {
+                    switch (exp.ClassName)
+                    {
+                        case "BioWorldInfo" when exp.ObjectName == "BioWorldInfo":
+                            bioworldinfo = exp;
+                            continue;
+                        case "LevelStreamingKismet" when exp.ObjectName == "LevelStreamingKismet":
+                            levelStreamingKismets.Add(exp);
+                            continue;
+                    }
+                }
+
+                levelStreamingKismets = levelStreamingKismets
+                    .OrderBy(o => o.GetProperty<NameProperty>("PackageName").ToString()).ToList();
+                if (bioworldinfo != null)
+                {
+                    var streamingLevelsProp =
+                        bioworldinfo.GetProperty<ArrayProperty<ObjectProperty>>("StreamingLevels") ??
+                        new ArrayProperty<ObjectProperty>("StreamingLevels");
+
+                    streamingLevelsProp.Clear();
+                    foreach (ExportEntry exp in levelStreamingKismets)
+                    {
+                        streamingLevelsProp.Add(new ObjectProperty(exp.UIndex));
+                    }
+
+                    bioworldinfo.WriteProperty(streamingLevelsProp);
+                }
+                else
+                {
+                    throw new Exception("No BioWorldInfo object found in this file.");
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Error setting streaming levels:\n{e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Converts a hex string to its byte representation.
+        /// </summary>
+        /// <param name="hex">Hex string to convert.</param>
+        /// <returns>Byte representation of the hex string.</returns>
+        public static byte[] HexToBytes(string hex)
+        {
+            byte[] bytes = new byte[hex.Length / 2];
+            for (int i = 0; i < hex.Length; i += 2)
+            {
+                bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+            }
+            return bytes;
+        }
+
+        /// <summary>
+        /// Checks if a dest position is within a given distance of the origin.
+        /// </summary>
+        /// <param name="origin">Origin position.</param>
+        /// <param name="dest">Dest position to check.</param>
+        /// <param name="dist">Max distance from origin.</param>
+        /// <returns>True if the dest is within dist</returns>
+        public static bool InDist(float origin, float dest, float dist)
+        {
+            return Math.Abs((dest - origin)) <= dist;
+        }
+
+        /// <summary>
+        /// Calculates the FNV132 hash of the given string.
+        /// IMPORTANT: This may not be compeletely bug-free or may be missing a couple of details, but so far it works.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns>The decimal representation of the hash.</returns>
+        public static uint CalculateFNV132Hash(string name)
+        {
+            byte[] bytedName = Encoding.ASCII.GetBytes(name.ToLower()); // Wwise automatically lowecases the input
+
+            // FNV132 hashing algorithm
+            uint hash = 2166136261;
+            foreach (byte namebyte in bytedName)
+            {
+                hash = ((hash * 16777619) ^ namebyte) & 0xFFFFFFFF;
+            }
+            return hash;
+        }
+
+        /// <summary>
+        /// Generate a random ID, using a provided Random object.
+        /// </summary>
+        /// <param name="random">Random object to generate from.</param>
+        /// <returns>Random ID</returns>
+        public static uint GenerateRandomID(Random random)
+        {
+            byte[] randomID = new byte[4];
+            random.NextBytes(randomID);
+            return BitConverter.ToUInt32(randomID, 0);
+        }
+
+        /// <summary>
+        /// Convert a big endian hex to its little endian representation.
+        /// </summary>
+        /// <param name="bigEndian">Endian to convert.</param>
+        /// <returns>Little endian.</returns>
+        public static string BigToLittleEndian(string bigEndian)
+        {
+            byte[] asCurrentEndian = new byte[4];
+            string littleEndian = "";
+            for (int i = 0; i < 4; i++)
+            {
+                asCurrentEndian[i] = Convert.ToByte(bigEndian.Substring(i * 2, 2), 16);
+                littleEndian = $"{asCurrentEndian[i]:X2}{littleEndian}";
+            }
+            return littleEndian;
+        }
+
+        /// <summary>
+        /// Prompts the user for an int, verifying that the int is valid.
+        /// </summary>
+        /// <param name="msg">Message to display for the prompt.</param>
+        /// <param name="err">Error message to display.</param>
+        /// <param name="biggerThan">Number the input must be bigger than. If not provided -2,147,483,648 will be used.</param>
+        /// <param name="title">Title for the prompt.</param>
+        /// <returns>The input int.</returns>
+        public static int PromptForInt(string msg, string err, int biggerThan = -2147483648, string title = "")
+        {
+            if (PromptDialog.Prompt(null, msg, title) is string stringPrompt)
+            {
+                int intPrompt;
+                if (string.IsNullOrEmpty(stringPrompt) || !int.TryParse(stringPrompt, out intPrompt) || !(intPrompt > biggerThan))
+                {
+                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
+                    return -1;
+                }
+                return intPrompt;
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Prompts the user for a float, verifying that the float is valid.
+        /// </summary>
+        /// <param name="msg">Message to display for the Prompt.</param>
+        /// <param name="err">Error message to display.</param>
+        /// <param name="title">Title for the Prompt.</param>
+        /// <returns>The input int.</returns>
+        public static float PromptForFloat(string msg, string err, string title = "")
+        {
+            if (PromptDialog.Prompt(null, msg, title) is string stringPrompt)
+            {
+                float floatPrompt;
+                if (string.IsNullOrEmpty(stringPrompt) || !float.TryParse(stringPrompt, out floatPrompt))
+                {
+                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
+                    return -1;
+                }
+                return floatPrompt;
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Prompts the user for a string, verifying tha the string is valid.
+        /// </summary>
+        /// <param name="msg">Message to display for the Prompt.</param>
+        /// <param name="err">Error message to display.</param>
+        /// <returns>The input string.</returns>
+        public static string PromptForStr(string msg, string err)
+        {
+            if (PromptDialog.Prompt(null, msg) is string str)
+            {
+                if (string.IsNullOrEmpty(str))
+                {
+                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
+                    return null;
+                }
+                return str;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Prompts the user for a reference, verifying tha the reference is valid.
+        /// </summary>
+        /// <param name="msg">Message to display for the Prompt.</param>
+        /// <param name="err">Error message to display.</param>
+        /// <returns>The input reference.</returns>
+        public static string PromptForRef(string msg, string err)
+        {
+            if (PromptDialog.Prompt(null, msg) is string stringRef)
+            {
+                int intRef;
+                if (string.IsNullOrEmpty(stringRef) || !int.TryParse(stringRef, out intRef))
+                {
+                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
+                    return null;
+                }
+                return intRef.ToString();
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Prompts the user for Yes/No, and returns their response.
+        /// </summary>
+        /// <param name="msg">Message to display.</param>
+        /// <param name="caption">Caption to display.</param>
+        /// <returns>Whether the user selected Yes or No.</returns>
+        public static bool PromptForBool(string msg, string caption)
+        {
+            return MessageBoxResult.Yes == MessageBox.Show(msg, caption, MessageBoxButton.YesNo);
+        }
+        #endregion
+    }
+}

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Dialogue Editor/DialogueEditorExperiments/DialogueEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Dialogue Editor/DialogueEditorExperiments/DialogueEditorExperimentsE.cs
@@ -1,15 +1,22 @@
 ﻿using LegendaryExplorer.Dialogs;
 using LegendaryExplorer.UserControls.ExportLoaderControls;
 using LegendaryExplorerCore.Dialogue;
+using LegendaryExplorerCore.Helpers;
 using LegendaryExplorerCore.Kismet;
+using LegendaryExplorerCore.Matinee;
 using LegendaryExplorerCore.Misc;
 using LegendaryExplorerCore.Packages;
 using LegendaryExplorerCore.Packages.CloningImportingAndRelinking;
 using LegendaryExplorerCore.Unreal;
 using LegendaryExplorerCore.Unreal.BinaryConverters;
+using LegendaryExplorerCore.Unreal.ObjectInfo;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using static LegendaryExplorer.Misc.ExperimentsTools.SharedMethods;
+using static LegendaryExplorer.Misc.ExperimentsTools.DialogueAutomations;
+using static LegendaryExplorer.Misc.ExperimentsTools.SequenceAutomations;
 
 namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
 {
@@ -20,25 +27,25 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
     {
         #region Update Native Node String Ref
         /// <summary>
-        /// Change the node's lineref and the parts of the FXA, WwiseStream, and WwwiseEvents
+        /// Change the node's LineRef and the references to it in the FXA and audio elements.
         /// that include it so it doesn't break
         /// </summary>
         /// <param name="dew">Current DE window.</param>
-        public static void UpdateNativeNodeStringRef(DialogueEditorWindow dew)
+        public static void UpdateAudioNodeStrRef(DialogueEditorWindow dew)
         {
-            DialogueNodeExtended selectedDialogueNode = dew.SelectedDialogueNode;
+            DialogueNodeExtended node = dew.SelectedDialogueNode;
 
-            if (dew.Pcc == null || selectedDialogueNode == null) { return; }
+            if (dew.Pcc == null || node == null) { return; }
 
             // Need to check if currStringRef exists
-            string currStringRef = selectedDialogueNode.LineStrRef.ToString();
+            string currStringRef = node.LineStrRef.ToString();
             if (string.IsNullOrEmpty(currStringRef))
             {
                 MessageBox.Show("The selected node does not have a Line String Ref, which is required in order to programatically replace the required elements.", "Warning", MessageBoxButton.OK);
                 return;
             }
 
-            string newStringRef = promptForRef("New line string ref:", "Not a valid line string ref.");
+            string newStringRef = PromptForRef("New line string ref:", "Not a valid line string ref.");
             if (string.IsNullOrEmpty(newStringRef))
             {
                 return;
@@ -58,7 +65,7 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
             if (pcc.Game.IsGame1())
             {
                 // Remove the _F from the femaleFXA name, as it appears without it for female FXA lines.
-                string femaleFXAName = selectedDialogueNode.FaceFX_Female[..^2];
+                string femaleFXAName = node.FaceFX_Female[..^2];
 
                 // Manually find the selected female line, as LEX doesn't load it into the SelectedLine of the
                 // FaceFXAnimSetEditorControl_F for ME1.
@@ -94,10 +101,8 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
                 UpdateFaceFX(FXAControl_M, currStringRef, newStringRef);
             }
 
-            if (int.TryParse(newStringRef, out int intRef))
-            {
-                selectedDialogueNode.LineStrRef = intRef;
-            }
+
+            if (int.TryParse(newStringRef, out int intRef)) { node.LineStrRef = intRef; }
 
             MessageBox.Show($"The node now points to {newStringRef}.", "Success", MessageBoxButton.OK);
         }
@@ -109,7 +114,7 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
         /// <param name="wwiseEvent">WwiseStream to use to find the WwiseEvents.</param>
         /// <param name="oldRef">Part of the name to replace.</param>
         /// <param name="newRef">String to replace with.</param>
-        private static void UpdateWwiseEvent(IMEPackage pcc, ExportEntry wwiseEvent, string oldRef, string newRef)
+        public static void UpdateWwiseEvent(IMEPackage pcc, ExportEntry wwiseEvent, string oldRef, string newRef)
         {
             if (wwiseEvent == null) { return; }
 
@@ -122,7 +127,7 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
         /// <param name="wwiseStream">WwiseStream to update.</param>
         /// <param name="oldRef">Part of the name to replace.</param>
         /// <param name="newRef">String to replace with.</param>
-        private static void UpdateWwiseStream(ExportEntry wwiseStream, string oldRef, string newRef)
+        public static void UpdateWwiseStream(ExportEntry wwiseStream, string oldRef, string newRef)
         {
             if (wwiseStream == null) { return; }
 
@@ -161,47 +166,47 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
         /// <param name="oldRef">Part of the name to replace.</param>
         /// <param name="newRef">String to replace with.</param>
         /// <param name="femaleLine">Manually provided female SelectedLine. Used for ME1.</param>
-        private static void UpdateFaceFX(FaceFXAnimSetEditorControl FXAControl, string oldRef, string newRef, FaceFXLine femaleLine = null)
+        public static void UpdateFaceFX(FaceFXAnimSetEditorControl FXAControl, string oldRef, string newRef, FaceFXLine femaleLine = null)
         {
             if (FXAControl == null) { return; }
 
             FaceFXAnimSetEditorControl.IFaceFXBinary FaceFX = FXAControl.FaceFX;
 
-            FaceFXLine SelectedLine = null;
+            FaceFXLine selectedLine = null;
             if (femaleLine != null)
             {
-                SelectedLine = femaleLine;
+                selectedLine = femaleLine;
             }
             else
             {
-                SelectedLine = FXAControl.SelectedLine;
+                selectedLine = FXAControl.SelectedLine;
             }
 
-            if (SelectedLine == null) { return; }
+            if (selectedLine == null) { return; }
 
-            if (SelectedLine.Path != null)
+            if (selectedLine.Path != null)
             {
-                SelectedLine.Path = SelectedLine.Path.Replace(oldRef, newRef);
+                selectedLine.Path = selectedLine.Path.Replace(oldRef, newRef);
             }
-            if (SelectedLine.ID != null)
+            if (selectedLine.ID != null)
             {
-                SelectedLine.ID = SelectedLine.ID.Replace(oldRef, newRef);
+                selectedLine.ID = selectedLine.ID.Replace(oldRef, newRef);
             }
 
             // Change FaceFX name
-            if (SelectedLine.NameAsString != null)
+            if (selectedLine.NameAsString != null)
             {
-                string newName = SelectedLine.NameAsString.Replace(oldRef, newRef);
+                string newName = selectedLine.NameAsString.Replace(oldRef, newRef);
                 if (FaceFX.Names.Contains(newName))
                 {
-                    SelectedLine.NameIndex = FaceFX.Names.IndexOf(newName);
-                    SelectedLine.NameAsString = newName;
+                    selectedLine.NameIndex = FaceFX.Names.IndexOf(newName);
+                    selectedLine.NameAsString = newName;
                 }
                 else
                 {
                     FaceFX.Names.Add(newName);
-                    SelectedLine.NameIndex = FaceFX.Names.Count - 1;
-                    SelectedLine.NameAsString = newName;
+                    selectedLine.NameIndex = FaceFX.Names.Count - 1;
+                    selectedLine.NameAsString = newName;
                 }
             }
 
@@ -214,7 +219,7 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
         /// <param name="pcc">Pcc to operate on.</param>
         /// <param name="selectedLine">Selected FXA line.</param>
         /// <returns>WwiseEvent if found, null otherwise.</returns>
-        private static ExportEntry GetWwiseEvent(IMEPackage pcc, FaceFXLine selectedLine)
+        public static ExportEntry GetWwiseEvent(IMEPackage pcc, FaceFXLine selectedLine)
         {
             if (pcc == null || selectedLine == null) { return null; }
 
@@ -231,7 +236,7 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
         /// <param name="stringRef">StringRef to search for.</param>
         /// <param name="suffix">_m_ or _f_.</param>
         /// <returns>WwiseStream that matches the criteria, if any.</returns>
-        private static ExportEntry GetWwiseStream(IMEPackage pcc, ExportEntry wwiseEvent, string stringRef, string suffix)
+        public static ExportEntry GetWwiseStream(IMEPackage pcc, ExportEntry wwiseEvent, string stringRef, string suffix)
         {
             if (pcc == null || (pcc.Game is MEGame.ME1) || wwiseEvent == null) { return null; }
 
@@ -362,21 +367,6 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
 
             return lines.First();
         }
-
-        private static string promptForRef(string msg, string err)
-        {
-            if (PromptDialog.Prompt(null, msg) is string stringRef)
-            {
-                int intRef;
-                if (string.IsNullOrEmpty(stringRef) || !int.TryParse(stringRef, out intRef))
-                {
-                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
-                    return null;
-                }
-                return intRef.ToString();
-            }
-            return null;
-        }
         #endregion
 
         #region Clone Node And Sequence
@@ -397,7 +387,7 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
                     return;
                 }
 
-                int newID = promptForID("New node ExportID:", "Not a valid ExportID.");
+                int newID = PromptForInt("New node ExportID:", "Not a valid ExportID.", 0);
                 if (newID == 0) { return; }
 
                 if (selectedDialogueNode.ExportID.Equals(newID))
@@ -431,7 +421,7 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
                 ExportEntry sequence = KismetHelper.GetParentSequence(oldInterpData);
 
                 // Clone the Intero and Interpdata objects
-                ExportEntry newInterp = cloneObject(oldInterp, sequence);
+                ExportEntry newInterp = CloneObject(oldInterp, sequence);
                 ExportEntry newInterpData = EntryCloner.CloneTree(oldInterpData);
                 KismetHelper.AddObjectToSequence(newInterpData, sequence, true);
 
@@ -439,13 +429,13 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
                 ExportEntry newConvNode = null;
                 if (oldConvNode != null)
                 {
-                    newConvNode = cloneObject(oldConvNode, sequence);
+                    newConvNode = CloneObject(oldConvNode, sequence);
                     KismetHelper.CreateOutputLink(newConvNode, "Started", newInterp, 0);
                 }
 
                 if (oldEndNode != null)
                 {
-                    ExportEntry newEndNode = cloneObject(oldEndNode, sequence);
+                    ExportEntry newEndNode = CloneObject(oldEndNode, sequence);
                     KismetHelper.CreateOutputLink(newInterp, "Completed", newEndNode, 0);
                     KismetHelper.CreateOutputLink(newInterp, "Reversed", newEndNode, 0);
                 }
@@ -481,33 +471,1149 @@ namespace LegendaryExplorer.DialogueEditor.DialogueEditorExperiments
                 MessageBox.Show($"Node cloned and given the ExportID: {newID}.", "Success", MessageBoxButton.OK);
             }
         }
-
-        private static int promptForID(string msg, string err)
-        {
-            if (PromptDialog.Prompt(null, msg) is string strID)
-            {
-                int ID;
-                if (!int.TryParse(strID, out ID))
-                {
-                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
-                    return 0;
-                }
-                return ID;
-            }
-            return 0;
-        }
-
-        // From SequenceEditorWPF.xaml.cs
-        private static ExportEntry cloneObject(ExportEntry old, ExportEntry sequence, bool topLevel = true, bool incrementIndex = true)
-        {
-            //SeqVar_External needs to have the same index to work properly
-            ExportEntry exp = EntryCloner.CloneEntry(old, incrementIndex: incrementIndex && old.ClassName != "SeqVar_External");
-
-            KismetHelper.AddObjectToSequence(exp, sequence, topLevel);
-            // cloneSequence(exp);
-            return exp;
-        }
-
         #endregion
+
+        #region Link Nodes and Create Sequence
+        /// <summary>
+        /// Links all audio nodes in the conversation without an ExportID to the free ConvNodes in the sequence.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void LinkNodesFree(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedConv == null) { return; }
+
+            int convNodeIDBase = PromptForInt("New ExportIDs base for extra IDs that may be need to be created:",
+                "Not a valid base. It must be positive integer", -1, "New NodeID range");
+            if (convNodeIDBase == -1) { return; }
+
+            ConversationExtended conversation = dew.SelectedConv;
+
+            HashSet<int> usedIDs = new();
+            List<DialogueNodeExtended> nodes = new();
+            List<DialogueNodeExtended> remainingNodes = new();
+
+            List<DialogueNodeExtended> entryNodes = FilterAudioNodes(conversation.EntryList, el => el.ExportID < 1, usedIDs);
+            List<DialogueNodeExtended> replyNodes = FilterAudioNodes(conversation.ReplyList, el => el.ExportID < 1, usedIDs);
+
+            nodes.AddRange(entryNodes);
+            nodes.AddRange(replyNodes);
+
+            List<(int, ExportEntry, ExportEntry, ExportEntry, int)> elements = GetConvNodeElements((ExportEntry)dew.SelectedConv.Sequence, conversation, usedIDs, false);
+
+            // Assign ExportIDs to the dialogue nodes, and write the new StrRefIDs to the VOElements tracks
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                if (i >= elements.Count)
+                {
+                    // Store a list of nodes that couldn't get an ExportID
+                    int remainingCount = nodes.Count - elements.Count;
+                    if (remainingCount > 0)
+                    {
+                        remainingNodes.AddRange(nodes.GetRange(i, remainingCount));
+                    }
+                    break;
+                }
+
+                DialogueNodeExtended node = nodes[i];
+                (int exportID, ExportEntry VOElements, ExportEntry interpData, ExportEntry interp, int _) = elements[i];
+
+                // Write the new ExportID
+                node.NodeProp.Properties.AddOrReplaceProp(new IntProperty(exportID, "nExportID"));
+                // Update the Interp comment
+                interp.WriteProperty(GenerateObjComment(node.Line));
+                // Write the StringRef
+                UpdateInterpDataStrRefID(interpData, node.LineStrRef, VOElements);
+
+                usedIDs.Add(exportID); // Mark the ExportID as used
+            }
+
+            // Create the sequence objects for any nodes that are left without an ExportID
+            if (remainingNodes.Any())
+            {
+                CreateNodesSequence(dew.Pcc, conversation, convNodeIDBase, nodes, usedIDs);
+            }
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show("Linked all nodes without an ExportID.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Links all audio nodes in the conversation without an ExportID to the free ConvNodes that have a matching StringRef in the sequence.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void LinkNodesStrRef(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedConv == null) { return; }
+
+            int convNodeIDBase = 0;
+
+            bool createObjsForNotMatched = MessageBoxResult.Yes == MessageBox.Show(
+                "Generate new sequence objects with a basic VO track and new ExportIDs for nodes that don't have a match?",
+                "Generate new sequence objects", MessageBoxButton.YesNo);
+
+            if (createObjsForNotMatched)
+            {
+                convNodeIDBase = PromptForInt("New ExportIDs base for new IDs that may be needed:",
+                    "Not a valid base. It must be positive integer", -1, "New NodeID range");
+                if (convNodeIDBase == -1) { return; }
+            }
+
+            ConversationExtended conversation = dew.SelectedConv;
+
+            HashSet<int> usedIDs = new();
+            List<DialogueNodeExtended> nodes = new();
+            List<DialogueNodeExtended> notMatchedNodes = new();
+            List<string> notMatchedNodesNames = new(); // Used for the result message
+
+            List<DialogueNodeExtended> entryNodes = FilterAudioNodes(conversation.EntryList, el => el.ExportID < 1, usedIDs);
+            List<DialogueNodeExtended> replyNodes = FilterAudioNodes(conversation.ReplyList, el => el.ExportID < 1, usedIDs);
+
+            nodes.AddRange(entryNodes);
+            nodes.AddRange(replyNodes);
+
+            // Key: StrRefID, Val: (ExportID, Interp, VOElements)
+            Dictionary<int, (int, ExportEntry, ExportEntry)> exportIDs = new();
+            foreach (var el in GetConvNodeElements((ExportEntry)dew.SelectedConv.Sequence, conversation, usedIDs))
+            {
+                // We do it like this instead of using ToDictionary to avoid errors with duplicate keys
+                (int ExportID, ExportEntry VOElements, ExportEntry _, ExportEntry interp, int StrRefID) = el;
+                exportIDs[StrRefID] = (ExportID, interp, VOElements);
+            }
+
+            // Assign ExportIDs to the dialogue nodes that match the StrRefID
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                if (exportIDs.TryGetValue(node.LineStrRef, out (int, ExportEntry, ExportEntry) el))
+                {
+                    (int exportID, ExportEntry interp, ExportEntry VOElements) = el;
+
+                    // Write the new ExportID
+                    node.NodeProp.Properties.AddOrReplaceProp(new IntProperty(exportID, "nExportID"));
+                    // Insert a defualt key if needed
+                    AddDefaultTrackKey(VOElements, true, 0, VOElements.GetProperties());
+                    // Update the Interp comment
+                    interp.WriteProperty(GenerateObjComment(node.Line));
+
+                    usedIDs.Add(exportID); // Mark the ExportID as used
+                }
+                else
+                {
+                    notMatchedNodes.Add(node);
+                    notMatchedNodesNames.Add(node.IsReply ? $"R{node.NodeCount}" : $"E{node.NodeCount}");
+                }
+            }
+
+            // Create the sequence objects for any nodes that are left without an ExportID
+            if (createObjsForNotMatched)
+            {
+                CreateNodesSequence(dew.Pcc, conversation, convNodeIDBase, notMatchedNodes, usedIDs);
+                // Clear the not matched nodes
+                notMatchedNodes = new();
+                notMatchedNodesNames = new();
+            }
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            string message = $"{nodes.Count - notMatchedNodes.Count} nodes matched.";
+            if (notMatchedNodesNames.Any())
+            {
+                message = $"{message} The following nodes' StrRefIDs were not found in any InterpData: \n{string.Join(", ", notMatchedNodesNames)}";
+            }
+
+            MessageBox.Show(message, "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Wrapper for CreateNodesSequence so it can used as an experiment.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void BatchCreateNodesSequenceExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedConv == null) { return; }
+
+            int convNodeIDBase = PromptForInt("New ExportIDs base:", "Not a valid base. It must be positive integer", -1, "New NodeID range");
+            if (convNodeIDBase == -1) { return; }
+
+            HashSet<int> usedIDs = new();
+            List<DialogueNodeExtended> nodes = new();
+
+            List<DialogueNodeExtended> entryNodes = FilterAudioNodes(dew.SelectedConv.EntryList, el => el.ExportID < 1, usedIDs);
+            List<DialogueNodeExtended> replyNodes = FilterAudioNodes(dew.SelectedConv.ReplyList, el => el.ExportID < 1, usedIDs);
+
+            nodes.AddRange(entryNodes);
+            nodes.AddRange(replyNodes);
+
+            CreateNodesSequence(dew.Pcc, dew.SelectedConv, convNodeIDBase, nodes, usedIDs);
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            string txtCount = nodes.Count == 1 ? "one audio node" : $"{nodes.Count} nodes";
+            MessageBox.Show($"Successfully created the sequence objects for {txtCount}.", "Success", MessageBoxButton.OK);
+        }
+
+
+        /// <summary>
+        /// Create the basic sequence objects for the selected audio node, if it doesn't have an ExportID.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void CreateNodeSequenceExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedDialogueNode == null) { return; }
+
+            int exportID = PromptForInt("New ExportID. If you input 0, a new ID will be generated:", "Not a valid ID. It must be positive integer", -1, "New NodeID");
+            if (exportID == -1) { return; }
+
+            DialogueNodeExtended node = dew.SelectedDialogueNode;
+
+            if (!IsAudioNode(node, out string errMsg))
+            {
+                MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
+                return;
+            }
+            if (node.Interpdata != null)
+            {
+                MessageBox.Show("The selected node already points to an InterpData.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            // If the provided ID is 0, generate an ID not in use in the conversation
+            List<int> newExportIDs = new();
+            if (exportID == 0)
+            {
+                HashSet<int> usedIDs = new();
+                List<DialogueNodeExtended> nodes = new();
+
+                List<DialogueNodeExtended> entryNodes = FilterAudioNodes(dew.SelectedConv.EntryList, el => el.ExportID < 1, usedIDs);
+                List<DialogueNodeExtended> replyNodes = FilterAudioNodes(dew.SelectedConv.ReplyList, el => el.ExportID < 1, usedIDs);
+
+                nodes.AddRange(entryNodes);
+                nodes.AddRange(replyNodes);
+
+                newExportIDs = GenerateIDs(100, 1, usedIDs);
+                exportID = newExportIDs.First();
+            }
+
+            // Write the new ExportID
+            node.NodeProp.Properties.AddOrReplaceProp(new IntProperty(exportID, "nExportID"));
+
+            // Create the required sequence elements and add it to the new exports list
+            List<ExportEntry> newExports = CreateDialogueNodeSequence(dew.Pcc, exportID, dew.SelectedConv.BioConvo.GetProp<IntProperty>("m_nResRefID").Value,
+                node.LineStrRef, node.Line);
+
+            if (newExports.Any())
+            {
+                KismetHelper.AddObjectsToSequence((ExportEntry)dew.SelectedConv.Sequence, false, newExports.ToArray());
+            }
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show($"Successfully created the sequence objects.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Create the basic sequence objects for all the audio nodes that don't have an ExportID.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="conversation">Conversation to create the objects for.</param>
+        /// <param name="convNodeIDBase">Base ID for the new ExportIDs.</param>
+        /// <param name="nodes">Nodes to generate the sequence objects for.</param>
+        /// <param name="usedIDs">ExportIDs in use.</param>
+        public static void CreateNodesSequence(IMEPackage pcc, ConversationExtended conversation, int convNodeIDBase,
+            List<DialogueNodeExtended> nodes, HashSet<int> usedIDs)
+        {
+            List<int> newExportIDs = GenerateIDs(convNodeIDBase, nodes.Count, usedIDs);
+            List<ExportEntry> newExports = new(); // Sequence objects to add
+
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                DialogueNodeExtended node = nodes[i];
+                int exportID = newExportIDs[i];
+
+                // Write the new ExportID
+                node.NodeProp.Properties.AddOrReplaceProp(new IntProperty(exportID, "nExportID"));
+
+                // Create the required sequence elements and add it to the new exports list
+                newExports.AddRange(CreateDialogueNodeSequence(pcc, exportID, conversation.BioConvo.GetProp<IntProperty>("m_nResRefID").Value,
+                    node.LineStrRef, node.Line));
+            }
+
+            if (newExports.Any())
+            {
+                KismetHelper.AddObjectsToSequence((ExportEntry)conversation.Sequence, false, newExports.ToArray());
+            }
+        }
+
+        /// <summary>
+        /// Create all the required sequence elements for a dialogue node. IT DOES NOT ADD THE EXPORTS TO THE SEQUENCE.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="nodeID">Node's ExportID.</param>
+        /// <param name="convResRefID">Conversation's ID.</param>
+        /// <param name="strRefID">Node's StrRefID.</param>
+        /// <param name="line">Text of the Node's StrRefID.</param>
+        /// <returns>List of created exports.</returns>
+        private static List<ExportEntry> CreateDialogueNodeSequence(IMEPackage pcc, int nodeID, int convResRefID, int strRefID, string line)
+        {
+            List<ExportEntry> exports = new();
+
+            // Create ConvNode
+            ExportEntry convNode = SequenceObjectCreator.CreateSequenceObject(pcc, "BioSeqEvt_ConvNode");
+            PropertyCollection convNodeProps = SequenceObjectCreator.GetSequenceObjectDefaults(pcc, "BioSeqEvt_ConvNode", pcc.Game);
+            convNodeProps.AddOrReplaceProp(new IntProperty(nodeID, "m_nNodeID"));
+            convNodeProps.AddOrReplaceProp(new IntProperty(convResRefID, "m_nConvResRefID"));
+            convNode.WriteProperties(convNodeProps);
+            exports.Add(convNode);
+
+            // Create Interp
+            ExportEntry interp = SequenceObjectCreator.CreateSequenceObject(pcc, "SeqAct_Interp");
+            PropertyCollection interpProps = SequenceObjectCreator.GetSequenceObjectDefaults(pcc, "SeqAct_Interp", pcc.Game);
+            interpProps.AddOrReplaceProp(new ArrayProperty<StrProperty>("m_aObjComment")
+            {
+                new StrProperty(line == "No Data" ? "" : line.Length <= 32 ? line : $"{line.AsSpan(0, 29)}...")
+            });
+            interpProps.AddOrReplaceProp(new BoolProperty(true, "bRewindOnPlay"));
+            // Add Conversation variable link
+            ArrayProperty<StructProperty> variableLinks = interpProps.GetProp<ArrayProperty<StructProperty>>("VariableLinks");
+            PropertyCollection props = GlobalUnrealObjectInfo.getDefaultStructValue(pcc.Game, "SeqVarLink", true);
+            props.AddOrReplaceProp(new StrProperty("Conversation", "LinkDesc"));
+            int index = pcc.FindImport("Engine.SeqVar_Object").UIndex;
+            props.AddOrReplaceProp(new ObjectProperty(index, "ExpectedType"));
+            props.AddOrReplaceProp(new IntProperty(1, "MinVars"));
+            props.AddOrReplaceProp(new IntProperty(255, "MaxVars"));
+            variableLinks.Add(new StructProperty("SeqVarLink", props));
+            interpProps.AddOrReplaceProp(variableLinks);
+            interp.WriteProperties(interpProps);
+            exports.Add(interp);
+
+            // Create EndCurrentConvNode
+            ExportEntry endNode = SequenceObjectCreator.CreateSequenceObject(pcc, "BioSeqAct_EndCurrentConvNode");
+            PropertyCollection endNodeProps = SequenceObjectCreator.GetSequenceObjectDefaults(pcc, "BioSeqAct_EndCurrentConvNode", pcc.Game);
+            endNode.WriteProperties(endNodeProps);
+            exports.Add(endNode);
+
+            // Create InterpData
+            ExportEntry interpData = SequenceObjectCreator.CreateSequenceObject(pcc, "InterpData");
+            PropertyCollection interpDataProps = SequenceObjectCreator.GetSequenceObjectDefaults(pcc, "InterpData", pcc.Game);
+            interpDataProps.AddOrReplaceProp(new FloatProperty(3, "InterpLength"));
+            interpData.WriteProperties(interpDataProps);
+            // Add Conversation group and VOElements track with its StrRefID
+            ExportEntry conversationGroup = MatineeHelper.AddNewGroupToInterpData(interpData, "Conversation");
+            ExportEntry VOElements = MatineeHelper.AddNewTrackToGroup(conversationGroup, "BioEvtSysTrackVOElements");
+            VOElements.WriteProperty(new IntProperty(strRefID, "m_nStrRefID"));
+            VOElements.WriteProperty(new ArrayProperty<StructProperty>("m_aTrackKeys")
+            {
+                new StructProperty("BioTrackKey", new PropertyCollection()
+                {
+                    new NameProperty("None", "KeyName"),
+                    new FloatProperty(0, "fTime")
+                }, "BioTrackKey")
+            });
+
+            exports.Add(interpData);
+
+            // Connect elements
+            KismetHelper.CreateOutputLink(convNode, "Started", interp, 0);
+            KismetHelper.CreateOutputLink(interp, "Completed", endNode, 0);
+            KismetHelper.CreateOutputLink(interp, "Reversed", endNode, 0);
+            KismetHelper.CreateVariableLink(interp, "Data", interpData);
+
+            return exports;
+        }
+
+        /// <summary>
+        /// Get a list of ExportIDs, VOElements track, Interp, and StrRefIDs of all the ConvNodes in the sequence.
+        /// </summary>
+        /// <param name="sequence">Sequence to get the elements from.</param>
+        /// <param name="conversation">BioConversation to operate on.</param>
+        /// <param name="usedIDs">List of ExportIDs that are already in use.</param>
+        /// <param name="ignoredNonVOs">Whether to ignore nodes that don't have a VOElements track.</param>
+        /// <returns>List of (ExportID, VOElements track, InterpData, Interp, StrRefID)</returns>
+        private static List<(int, ExportEntry, ExportEntry, ExportEntry, int)> GetConvNodeElements(ExportEntry sequence, ConversationExtended conversation, HashSet<int> usedIDs, bool ignoredNonVOs = true)
+        {
+            IMEPackage pcc = sequence.FileRef;
+
+            List<(int, ExportEntry, ExportEntry, ExportEntry, int)> elements = new();
+
+            List<IEntry> convNodes = KismetHelper.GetAllSequenceElements(sequence)
+                .Where(el => el.ClassName == "BioSeqEvt_ConvNode").ToList();
+
+            foreach (ExportEntry node in convNodes)
+            {
+                IntProperty m_nNodeID = node.GetProperty<IntProperty>("m_nNodeID");
+                // Skip nodes that don't have an ExportID, or an ExportID that is already in use
+                if (m_nNodeID == null || usedIDs.Contains(m_nNodeID.Value)) { continue; }
+
+                // Find the interp data
+                ExportEntry interpData = null;
+                List<ExportEntry> searchingExports = new() { node };
+
+                ExportEntry seqActInterp = conversation.recursiveFindSeqActInterp(searchingExports, new List<ExportEntry>(), 10);
+                if (seqActInterp == null) { continue; }
+
+                ArrayProperty<StructProperty> varLinksProp = seqActInterp.GetProperty<ArrayProperty<StructProperty>>("VariableLinks");
+
+                if (varLinksProp != null)
+                {
+                    foreach (StructProperty prop in varLinksProp)
+                    {
+                        string desc = prop.GetProp<StrProperty>("LinkDesc").Value; //ME3/ME2/ME1
+                        if (desc == "Data") //ME3/ME1
+                        {
+                            ArrayProperty<ObjectProperty> linkedVars = prop.GetProp<ArrayProperty<ObjectProperty>>("LinkedVariables");
+                            if (linkedVars != null && linkedVars.Any())
+                            {
+                                int datalink = linkedVars[0].Value;
+                                interpData = sequence.FileRef.GetUExport(datalink);
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                // Only consider as valid ExportIDs that lead to InterpDatas
+                if (interpData == null) { continue; }
+
+                // Store the StrRefID in the VOElements track, if one exists
+                int strRefID = GetVOStrRefID(interpData, out ExportEntry VOElements);
+
+                if (ignoredNonVOs)
+                {
+                    // Only consider as valid InterpDatas that contain a VOElements track
+                    if (VOElements == null) { continue; }
+                }
+
+                elements.Add((m_nNodeID.Value, VOElements, interpData, seqActInterp, strRefID));
+            }
+
+            return elements;
+        }
+
+        /// <summary>
+        /// Generate a list of IDs starting at base, of the given length, and skip IDs that are in the usedIDs list.
+        /// </summary>
+        /// <param name="baseID">Base num for the list.</param>
+        /// <param name="length">Target length of the list.</param>
+        /// <param name="usedIDs">IDs to skip.</param>
+        /// <returns>Generated IDs.</returns>
+        private static List<int> GenerateIDs(int baseID, int length, HashSet<int> usedIDs)
+        {
+            List<int> ids = new();
+
+            int count = 0;
+            while (count < length)
+            {
+                if (usedIDs != null && !usedIDs.Contains(baseID))
+                {
+                    ids.Add(baseID);
+                    count++;
+                }
+                baseID++;
+            }
+
+            return ids;
+        }
+        #endregion
+
+        #region Update VOs and Comments
+        /// <summary>
+        /// Update all the Interp comments and VOElements' StrRefIDs that are linked to the audio nodes of the selected conversation.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void BatchUpdateVOsAndCommentsExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedConv == null) { return; }
+
+            List<DialogueNodeExtended> nodes = new();
+            int updateCount = 0;
+
+            nodes.AddRange(dew.SelectedConv.EntryList);
+            nodes.AddRange(dew.SelectedConv.ReplyList);
+
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                if (IsAudioNode(node) && node.ExportID > 0)
+                {
+                    UpdateVOAndComment(node);
+                    updateCount += 1;
+                }
+            }
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            string txtCount = updateCount == 1 ? "one audio node" : $"{updateCount} nodes";
+            MessageBox.Show($"Successfully updated the StrRefID and Interp comment for {txtCount}.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Update the Interp comment and VOElement' StrRefID that are linked to the selected audio node.
+        /// Wrapper for UpdateVOAndComment so it can used as an experiment.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void UpdateVOAndCommentExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedDialogueNode == null) { return; }
+
+            DialogueNodeExtended node = dew.SelectedDialogueNode;
+
+            if (!IsAudioNode(node, out string errMsg))
+            {
+                MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
+                return;
+            }
+            if (node.Interpdata == null)
+            {
+                MessageBox.Show("The selected node doesn't point to an InterpData.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            UpdateVOAndComment(node);
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show($"Successfully updated the StrRefID and Interp comment for the selected node.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Update the StrRefID of the node's InterpData and the comment of the Interp linking to it.
+        /// </summary>
+        /// <param name="node">Node to update</param>
+        private static void UpdateVOAndComment(DialogueNodeExtended node)
+        {
+            ExportEntry interpData = node.Interpdata;
+
+            if (interpData != null && TryGetInterp(interpData, out ExportEntry interp))
+            {
+                UpdateInterpDataStrRefID(interpData, node.LineStrRef);
+                // Update the Interp comment
+                interp.WriteProperty(GenerateObjComment(node.Line));
+            }
+        }
+        #endregion
+
+        #region Add Conversation Defaults
+        /// <summary>
+        /// Add a Conversation group, and VOElements and SwitchCamera tracks to all audio nodes in the selected conversation.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void BatchAddConversationDefaultsExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedConv == null) { return; }
+
+            List<DialogueNodeExtended> nodes = new();
+
+            nodes.AddRange(dew.SelectedConv.EntryList);
+            nodes.AddRange(dew.SelectedConv.ReplyList);
+
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                if (IsAudioNode(node) && node.ExportID > 0 && node.Interpdata != null)
+                {
+                    AddConversationDefaultsToInterpData(node.Interpdata, node.LineStrRef);
+                }
+            }
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show($"Successfully added the default conversation elements to all audio nodes in the conversation.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Add a Conversation group, and VOElements and SwitchCamera tracks to the selected node.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void AddConversationDefaultsExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedDialogueNode == null) { return; }
+
+            DialogueNodeExtended node = dew.SelectedDialogueNode;
+
+            if (!IsAudioNode(node, out string errMsg))
+            {
+                MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
+                return;
+            }
+            if (node.Interpdata == null)
+            {
+                MessageBox.Show("The selected node doesn't point to an InterpData.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            AddConversationDefaultsToInterpData(node.Interpdata, node.LineStrRef);
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show($"Successfully added the default conversation elements to the selected node.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Add a Conversation group, and VOElements and SwitchCamera tracks to interpData.
+        /// </summary>
+        /// <param name="interpData">InterpData to add the elements to.</param>
+        /// <param name="strRefID">StrRefID for the VOElements track</param>
+        private static void AddConversationDefaultsToInterpData(ExportEntry interpData, int strRefID = 0)
+        {
+            if (!MatineeHelper.TryGetInterpGroup(interpData, "Conversation", out ExportEntry interpGroup))
+            {
+                interpGroup = MatineeHelper.AddNewGroupToInterpData(interpData, "Conversation");
+            }
+
+            if (!MatineeHelper.TryGetInterpTrack(interpGroup, "BioEvtSysTrackVOElements", out ExportEntry VOElements))
+            {
+                VOElements = MatineeHelper.AddNewTrackToGroup(interpGroup, "BioEvtSysTrackVOElements");
+            }
+            PropertyCollection props = VOElements.GetProperties();
+            props.AddOrReplaceProp(new IntProperty(strRefID, "m_nStrRefID"));
+            AddDefaultTrackKey(VOElements, false, 0, props);
+            VOElements.WriteProperties(props);
+
+            if (!MatineeHelper.TryGetInterpTrack(interpGroup, "BioEvtSysTrackSwitchCamera", out _))
+            {
+                ExportEntry SwitchCamera = MatineeHelper.AddNewTrackToGroup(interpGroup, "BioEvtSysTrackSwitchCamera");
+                MatineeHelper.AddDefaultPropertiesToTrack(SwitchCamera);
+            }
+        }
+        #endregion
+
+        #region Update Interp Lengths
+        /// <summary>
+        /// Update the InterpLength of all the audio nodes in the selectd conversation, based either on the FXA or the audio length.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void BatchUpdateInterpLengthsExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedConv == null) { return; }
+
+            bool byFXA = MessageBoxResult.Yes == MessageBox.Show(
+                "Calculate the InterpLengths by the FXA length? If not, the audio length will be used.",
+                "Calculate by FXA", MessageBoxButton.YesNo);
+
+            List<DialogueNodeExtended> nodes = new();
+
+            nodes.AddRange(dew.SelectedConv.EntryList);
+            nodes.AddRange(dew.SelectedConv.ReplyList);
+
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                if (IsAudioNode(node) && node.ExportID > 0 && node.Interpdata != null)
+                {
+                    UpdateInterpLength(node, byFXA, dew.FaceFXAnimSetEditorControl_F, dew.FaceFXAnimSetEditorControl_M);
+                }
+            }
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show($"Successfully updated the InterpLength of all audio nodes in the conversation.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Wrapper for UpdateInterpLength so it can be used on its own.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void UpdateInterpLengthExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedDialogueNode == null) { return; }
+
+            DialogueNodeExtended node = dew.SelectedDialogueNode;
+
+            if (!IsAudioNode(node, out string errMsg))
+            {
+                MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
+                return;
+            }
+            if (node.Interpdata == null)
+            {
+                MessageBox.Show("The selected node doesn't point to an InterpData.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            bool byFXA = MessageBoxResult.Yes == MessageBox.Show(
+                "Calculate the InterpLengths by the FXA length? If not, the audio length will be used.",
+                "Calculate by FXA", MessageBoxButton.YesNo);
+
+            UpdateInterpLength(node, byFXA, dew.FaceFXAnimSetEditorControl_F, dew.FaceFXAnimSetEditorControl_M);
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show($"Successfully updated the InterpLength of the selected audio node.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Update the InterpLength of the Node, based either on the FXA or the audio length.
+        /// </summary>
+        /// <param name="node">Node to update.</param>
+        /// <param name="byFXA">Whether to update the length by the FXA length, or the audio one.</param>
+        private static void UpdateInterpLength(DialogueNodeExtended node, bool byFXA, FaceFXAnimSetEditorControl animControlF, FaceFXAnimSetEditorControl animControlM)
+        {
+            float interpLength = 0;
+            IMEPackage pcc = node.Interpdata.FileRef;
+
+            if (byFXA)
+            {
+                // Refresh the export of the FaceFX control. This is done so that the batch version can get the lengths
+                // without having to select the converastion first, because otherwise you get the previously loaded export.
+                // Without this, it also causes issues when you need different sets from the same file.
+                //
+                // How to improve this to avoid refreshing on EVERY node? We could probably split the nodes by set, and only
+                // refresh once per set, or we could redo the animation Points loading and length calculation code and avoid using the
+                // FaceFXAnimSetEditorControl altogether, but both would take more time to implement than the 2 to 5 seconds the
+                // batch experiment takes on long conversations.
+                if (node.SpeakerTag?.FaceFX_Female is ExportEntry faceFX_f)
+                {
+                    animControlF.LoadExport(faceFX_f);
+                }
+                else
+                {
+                    animControlF.UnloadExport();
+                }
+
+                if (node.SpeakerTag?.FaceFX_Male is ExportEntry faceFX_m)
+                {
+                    animControlM.LoadExport(faceFX_m);
+                }
+                else
+                {
+                    animControlM.UnloadExport();
+                }
+
+                FaceFXLineEntry femaleLine = null;
+                if (animControlF != null && animControlF.Lines != null)
+                {
+                    femaleLine = animControlF.Lines.FirstOrDefault(line => line.TLKID == node.LineStrRef);
+                }
+
+                FaceFXLineEntry maleLine = null;
+                if (animControlM != null && animControlM.Lines != null)
+                {
+                    maleLine = animControlM.Lines.FirstOrDefault(line => line.TLKID == node.LineStrRef);
+                }
+
+                float lengthF = 0;
+                float lengthM = 0;
+                if (femaleLine != null) { lengthF = femaleLine.Length; }
+                if (maleLine != null) { lengthM = maleLine.Length; }
+
+                interpLength = lengthF > lengthM ? lengthF : lengthM;
+                interpLength += 0.22F; // Add fadeout time
+            }
+            else
+            {
+                string lineRef = $"{node.LineStrRef}";
+                IEnumerable<ExportEntry> references = pcc.Exports.Where(exp => exp.ObjectName.Name.Contains(lineRef)
+                    && exp.ClassName == (pcc.Game.IsGame1() ? "SoundNodeWave" : "WwiseEvent"));
+
+                if (references != null)
+                {
+                    // We'll record the duration of the longest reference
+                    foreach (ExportEntry reference in references)
+                    {
+                        FloatProperty duration = reference.GetProperty<FloatProperty>(pcc.Game.IsGame1() ? "Duration" : "DurationSeconds");
+                        if (duration != null) { interpLength = duration.Value > interpLength ? duration.Value : interpLength; }
+                    }
+                }
+            }
+
+            // If the first VO starts beyond zero, add that offset to the length
+            if (MatineeHelper.TryGetInterpGroup(node.Interpdata, "Conversation", out ExportEntry conversation))
+            {
+                if (MatineeHelper.TryGetInterpTrack(conversation, "BioEvtSysTrackVOElements", out ExportEntry VOElements))
+                {
+                    ArrayProperty<StructProperty> m_aTrackKeys = VOElements.GetProperty<ArrayProperty<StructProperty>>("m_aTrackKeys");
+
+                    if (m_aTrackKeys != null && m_aTrackKeys.Any())
+                    {
+                        interpLength += m_aTrackKeys.First().GetProp<FloatProperty>("fTime").Value;
+                    }
+                }
+            }
+
+            node.Interpdata.WriteProperty(new FloatProperty(interpLength, "InterpLength"));
+        }
+        #endregion
+
+        #region Generate LE1 Audio Links
+        /// <summary>
+        /// Create SoundCues and SoundNodeWaves, and link them to the FaceFX for all audio nodes that don't have one.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void BatchGenerateLE1AudioLinksExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.Pcc.Game != MEGame.LE1 || dew.SelectedConv == null) { return; }
+
+            int bioStreamingDataID = PromptForInt("BioStreamingData export number:", "Not a valid export number. It must be positive integer", 0, "BioStreamingData");
+            if (!dew.Pcc.TryGetEntry(bioStreamingDataID, out IEntry entry) || entry.ClassName != "BioSoundNodeWaveStreamingData")
+            {
+                MessageBox.Show("The provided export is not a BioStreamingData.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string baseName = GetBaseConversationName(dew.SelectedConv.Export);
+            if (string.IsNullOrEmpty(baseName))
+            {
+                MessageBox.Show("Could not find a common base name between the conversation and the tlk file set.\n" +
+                    "Ensure they both have a common prefix, which will be used as the based of the SoundNodeWave names.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            List<DialogueNodeExtended> nodes = new();
+
+            nodes.AddRange(dew.SelectedConv.EntryList);
+            nodes.AddRange(dew.SelectedConv.ReplyList);
+
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                if (IsAudioNode(node) && node.ExportID > 0 && node.Interpdata != null)
+                {
+                    GenerateLE1AudioLinks(node, (ExportEntry)dew.Pcc.GetEntry(dew.SelectedConv.Sequence.idxLink),
+                        baseName, bioStreamingDataID);
+                }
+            }
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show($"Successfully created the SoundCue, SoundNodeWave, and linked it to the FaceFX for all the audio nodes.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Create SoundCues and SoundNodeWaves, and link them to the FaceFX for the selected audio node.
+        /// Wrapper for GenerateLE1AudioLinks so it can be used on its own.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void GenerateLE1AudioLinksExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.Pcc.Game != MEGame.LE1 || dew.SelectedDialogueNode == null) { return; }
+
+            DialogueNodeExtended node = dew.SelectedDialogueNode;
+
+            if (!IsAudioNode(node, out string errMsg))
+            {
+                MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
+                return;
+            }
+            if (node.Interpdata == null)
+            {
+                MessageBox.Show("The selected node doesn't point to an InterpData.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            int bioStreamingDataID = PromptForInt("BioStreamingData export number:", "Not a valid export number. It must be positive integer", 0, "BioStreamingData");
+            if (!dew.Pcc.TryGetEntry(bioStreamingDataID, out IEntry entry) || entry.ClassName != "BioSoundNodeWaveStreamingData")
+            {
+                MessageBox.Show("The provided export is not a BioStreamingData.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string baseName = GetBaseConversationName(dew.SelectedConv.Export);
+            if (string.IsNullOrEmpty(baseName))
+            {
+                MessageBox.Show("Could not find a common base name between the conversation and the tlk file set.\n" +
+                    "Ensure they both have a common prefix, which will be used as the based of the SoundNodeWave names.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            GenerateLE1AudioLinks(node, (ExportEntry)dew.Pcc.GetEntry(dew.SelectedConv.Sequence.idxLink),
+                baseName, bioStreamingDataID);
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show($"Successfully created the SoundCue, SoundNodeWave, and linked it to the FaceFX for the selected audio node.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Create SoundCues and SoundNodeWaves, and link them to the FaceFX for the selected audio node.
+        /// </summary>
+        /// <param name="node">Node to generate the links for.</param>
+        /// <param name="audioPackage">Package containing the audio elements.</param>
+        /// <param name="baseName">Base name for the new elements.</param>
+        /// <param name="bioStreamingDataID">BioStreamingData to link to the SoundNodeWaves.</param>
+        private static void GenerateLE1AudioLinks(DialogueNodeExtended node, ExportEntry audioPackage, string baseName, int bioStreamingDataID)
+        {
+            IMEPackage pcc = node.Interpdata.FileRef;
+            string strRefAsString = $"{node.LineStrRef}";
+            ExportEntry soundNodeWaveF = null;
+            ExportEntry soundCueF = null;
+            ExportEntry soundNodeWaveM = null;
+            ExportEntry soundCueM = null;
+
+            // Try to find any SoundNodeWaves or SoundCues, in case we need to only generate one or the other
+            foreach (ExportEntry exp in audioPackage.GetAllDescendants())
+            {
+                if (exp.ClassName == "SoundCue" && exp.ObjectName.Name.Contains(strRefAsString))
+                {
+                    if (exp.ObjectName.Name.EndsWith("_M", StringComparison.CurrentCultureIgnoreCase)) { soundCueM = exp; }
+                    else { soundCueF = exp; }
+                }
+                else if (exp.ClassName == "SoundNodeWave" && exp.ObjectName.Name.Contains(strRefAsString))
+                {
+                    if (exp.ObjectName.Name.EndsWith("_M", StringComparison.CurrentCultureIgnoreCase)) { soundNodeWaveM = exp; }
+                    else { soundNodeWaveF = exp; }
+                }
+
+                if (soundCueM != null && soundNodeWaveM != null && soundCueF != null && soundNodeWaveF != null) // Stop if we found all the elements
+                {
+                    break;
+                }
+            }
+
+            ExportEntry FXSetM = node.SpeakerTag.FaceFX_Male as ExportEntry;
+            ExportEntry FXSetF = node.SpeakerTag.FaceFX_Female as ExportEntry;
+
+            if (FXSetM != null)
+            {
+                soundNodeWaveM ??= GenerateSoundNodeWave(pcc, audioPackage, baseName, node.LineStrRef, bioStreamingDataID, true);
+                soundCueM ??= GenerateSoundCue(pcc, audioPackage, soundNodeWaveM.UIndex, node.LineStrRef, true);
+
+                LinkLE1AudioToFaceFX(FXSetM, soundCueM, soundNodeWaveM.ObjectName.Name, node.LineStrRef);
+            }
+            if (FXSetF != null)
+            {
+                soundNodeWaveF ??= GenerateSoundNodeWave(pcc, audioPackage, baseName, node.LineStrRef, bioStreamingDataID, false);
+                soundCueF ??= GenerateSoundCue(pcc, audioPackage, soundNodeWaveF.UIndex, node.LineStrRef, false);
+
+                LinkLE1AudioToFaceFX(FXSetF, soundCueF, soundNodeWaveF.ObjectName.Name, node.LineStrRef);
+            }
+        }
+
+        /// <summary>
+        /// Link audio, passed by id, to a new line and add it to the FaceFX set editor control.
+        /// </summary>
+        /// <param name="faceFXAnimSet">FaceFX anim set to link to.</param>
+        /// <param name="soundCue">SoundCue to link.</param>
+        /// <param name="id">SoundNodeWave name.</param>
+        /// <param name="strRefID">TLK StrRefID, for the FXA name.</param>
+        private static void LinkLE1AudioToFaceFX(ExportEntry faceFXAnimSet, ExportEntry soundCue, string id, int strRefID)
+        {
+            if (faceFXAnimSet == null) { return; }
+
+            FaceFXAnimSet faceFX = faceFXAnimSet.GetBinaryData<FaceFXAnimSet>();
+            if (faceFX == null) { return; }
+
+            string lineName = $"FXA_{strRefID}{(faceFXAnimSet.ObjectName.Name.EndsWith("_M", StringComparison.CurrentCultureIgnoreCase) ? "_M" : "")}";
+
+            if (faceFX.Lines.Any(l => l.NameAsString == lineName)) { return; } // No need to add a new line
+
+            FaceFXLine line = new()
+            {
+                NameIndex = faceFX.Names.Count,
+                NameAsString = lineName,
+                AnimationNames = new(),
+                Points = new(),
+                NumKeys = new(),
+                FadeInTime = 0.16F,
+                FadeOutTime = 0.22F,
+                Path = soundCue.InstancedFullPath,
+                ID = id,
+                Index = faceFX.Lines.Count
+            };
+
+            faceFX.Names.Add(line.NameAsString);
+            faceFX.Lines.Add(line);
+
+            PropertyCollection props = faceFXAnimSet.GetProperties();
+            ArrayProperty<ObjectProperty> referencedSoundCues = props.GetProp<ArrayProperty<ObjectProperty>>("ReferencedSoundCues")
+                ?? new ArrayProperty<ObjectProperty>("ReferencedSoundCues");
+
+            referencedSoundCues.Add(new ObjectProperty(soundCue.UIndex)); // ASSUMES: If the line wasn't in the binary, it also doesn't referenced the SoundCue
+            faceFXAnimSet.WritePropertiesAndBinary(props, faceFX);
+        }
+
+        /// <summary>
+        /// Generate a SoundNodeWave based on the conversation name and strRefID.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="parent">Parent package for the node</param>
+        /// <param name="baseName">Base name for the node.</param>.
+        /// <param name="strRefID">Node's StrRefID.</param>
+        /// <param name="bioStreamingData">UIndex of the BioStreamingData.</param>
+        /// <param name="isMale">Whether the SoundCue is for a male.</param>
+        /// <returns>Generated SoundNodeWave.</returns>
+        private static ExportEntry GenerateSoundNodeWave(IMEPackage pcc, IEntry parent, string baseName, int strRefID, int bioStreamingData, bool isMale)
+        {
+            string name = $"{baseName}:VO_{strRefID}{(isMale ? "_M" : "")}";
+            PropertyCollection props = new()
+            {
+                new FloatProperty(1, "Volume"),
+                new ObjectProperty(bioStreamingData, "BioStreamingData")
+            };
+            return CreateExport(pcc, new NameReference(name), "SoundNodeWave", parent, props, SoundNodeWave.Create());
+        }
+
+        /// <summary>
+        /// Generate a SoundNodeWave based on the conversation name and strRefID.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="parent">Parent package for the node</param>
+        /// <param name="soundNodeWave">SoundNodeWave to reference.</param>
+        /// <param name="strRefID">Node's StrRefID.</param>
+        /// <param name="isMale">Whether the SoundCue is for a male.</param>
+        /// <returns>Generated SoundCue.</returns>
+        private static ExportEntry GenerateSoundCue(IMEPackage pcc, IEntry parent, int soundNodeWave, int strRefID, bool isMale)
+        {
+            string name = $"VO_{strRefID}{(isMale ? "_M" : "")}";
+            PropertyCollection props = new()
+            {
+                new NameProperty("DLG", "SoundGroup"),
+                new ObjectProperty(soundNodeWave, "FirstNode")
+            };
+            return CreateExport(pcc, new NameReference(name), "SoundCue", parent, props, SoundCue.Create());
+        }
+
+        /// <summary>
+        /// Get the base name of the bioConversation.
+        /// </summary>
+        /// <param name="bioConversation">BioConversation to get the name from.</param>
+        /// <returns>Base conversation name. Empty string if couldn't get it.</returns>
+        private static string GetBaseConversationName(ExportEntry bioConversation)
+        {
+            IMEPackage pcc = bioConversation.FileRef;
+            string baseName = "";
+
+            ObjectProperty m_oTlkFileSet = bioConversation.GetProperty<ObjectProperty>("m_oTlkFileSet");
+            if (m_oTlkFileSet != null && m_oTlkFileSet.Value != 0)
+            {
+                ExportEntry tlkFileSet = pcc.GetUExport(m_oTlkFileSet.Value);
+                // All Tlk file sets begin with TlkSet_, followed by the name they have in common with the package
+                baseName = GetCommonPrefix(tlkFileSet.ObjectName.Name[7..], bioConversation.ObjectName.Name);
+            }
+
+            return baseName;
+        }
+        #endregion
+
+        /// <summary>
+        /// Assign ExportIDs and TLK refs to Autocontinues.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void FixAutocontinues(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedConv == null) { return; }
+
+            int exportID = PromptForInt("Base ExportID for Autocontinues:",
+                "Not a valid base. It must be positive integer", -1, "New ExportID base");
+            if (exportID == -1) { return; }
+
+            int tlkRef = PromptForInt("Base TLK Ref for Autocontinues:",
+                "Not a valid base. It must be positive integer", -1, "New TLK Ref base");
+            if (tlkRef == -1) { return; }
+
+            ConversationExtended conversation = dew.SelectedConv;
+
+            List<DialogueNodeExtended> nodes = new();
+            nodes.AddRange(conversation.EntryList);
+            nodes.AddRange(conversation.ReplyList);
+
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                if (node.ReplyType == EReplyTypes.REPLY_AUTOCONTINUE)
+                {
+                    if (node.ExportID < 0) { node.NodeProp.Properties.AddOrReplaceProp(new IntProperty(exportID++, "nExportID")); }
+
+                    if (node.LineStrRef < 0) { node.NodeProp.Properties.AddOrReplaceProp(new StringRefProperty(tlkRef++, "srText")); }
+                }
+            }
+
+            dew.RecreateNodesToProperties(dew.SelectedConv);
+            dew.ForceRefreshCommand.Execute(null);
+
+            MessageBox.Show("Assigned an ExportID and TLK Ref to all Autoncontinue nodes that were missing it.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Remove the given InterpTrack from all matching InterpGroups in the conversation's InterpDatas.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void BatchUnlistTrackFromGroupExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedConv == null) { return; }
+
+            string groupName = PromptForStr("InterpGroup's name to unlist the track from:", "Invalid group name.");
+            string trackName = PromptForStr("InterpTrack class name to unlist:", "Invalid track name.");
+
+            List<DialogueNodeExtended> nodes = new();
+            nodes.AddRange(dew.SelectedConv.EntryList);
+            nodes.AddRange(dew.SelectedConv.ReplyList);
+
+            int updateCount = 0;
+
+            foreach (DialogueNodeExtended node in nodes)
+            {
+                if (node.Interpdata == null) { continue; }
+
+                if (UnlistTrackFromGroup(dew.Pcc, groupName, trackName, node.Interpdata))
+                {
+                    updateCount++;
+                }
+            }
+
+            MessageBox.Show($"Successfully unlisted {trackName} InterpTracks from {updateCount} {groupName} InterpGroups.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Wrapper for UnlistTrackFromGroup.
+        /// </summary>
+        /// <param name="dew">Current Dialogue Editor instance.</param>
+        public static void UnlistTrackFromGroupExperiment(DialogueEditorWindow dew)
+        {
+            if (dew.Pcc == null || dew.SelectedDialogueNode == null) { return; }
+
+            string groupName = PromptForStr("InterpGroup's name to unlist the track from:", "Invalid group name.");
+            string trackName = PromptForStr("InterpTrack class name to unlist:", "Invalid track name.");
+
+            DialogueNodeExtended node = dew.SelectedDialogueNode;
+
+            if (node.Interpdata == null)
+            {
+                MessageBox.Show("The selected node does not contain an InterpData.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            if (UnlistTrackFromGroup(dew.Pcc, groupName, trackName, node.Interpdata))
+            {
+                MessageBox.Show($"Successfully unlisted {trackName} InterpTrack from {groupName} InterpGroup.", "Success", MessageBoxButton.OK);
+            }
+            else
+            {
+                MessageBox.Show($"Could not find a matching {trackName} InterpTrack and/or {groupName} InterpGroup.", "Warning", MessageBoxButton.OK);
+            
+            }
+        }
+
+        /// <summary>
+        /// Remove the given InterpTrack from the matching InterpGroups in Node's InterpData.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="groupName">InterpGroup to search on.</param>
+        /// <param name="trackName">Class of track to unlist.</param>
+        /// <param name="interpData">InterpData to search on.</param>
+        /// <returns></returns>
+        private static bool UnlistTrackFromGroup(IMEPackage pcc, string groupName, string trackName, ExportEntry interpData)
+        {
+            if (!MatineeHelper.TryGetInterpGroup(interpData, groupName, out ExportEntry interpGroup)) { return false; }
+
+            ArrayProperty<ObjectProperty> interpTracks = interpGroup.GetProperty<ArrayProperty<ObjectProperty>>("InterpTracks");
+            if (interpTracks == null) { return false; }
+
+            interpGroup.WriteProperty(
+                new ArrayProperty<ObjectProperty>(
+                interpTracks.Where(trackRef =>
+                {
+                    if (!pcc.TryGetUExport(trackRef.Value, out ExportEntry track)) { return false; }
+                    return (track.ClassName != trackName);
+                }), "InterpTracks"));
+
+            return true;
+        }
     }
 }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Dialogue Editor/DialogueEditorExperiments/DialogueExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Dialogue Editor/DialogueEditorExperiments/DialogueExperimentsMenuControl.xaml
@@ -13,7 +13,22 @@
     <MenuItem Header=" &gt;&gt; DO NOT USE IF YOU DON'T KNOW WHAT YOU'RE DOING &gt;&lt;" IsEnabled="False"/>
     <MenuItem Header=" &gt;&gt; Text may not reflect actual functionality &lt;&lt;" IsEnabled="False"/>
     <MenuItem Header="Exkywor's buttons for lazy people">
-        <MenuItem Header="Change Native Node StringRef" Click="UpdateNativeNodeStringRef_Click" ToolTip="Updates a native node's VOElements, FXA, and Wwisestream stringrefs."/>
+        <MenuItem Header="Change Audio Node StringRef" Click="UpdateAudioNodeStrRef_Click" ToolTip="Updates an audio node's VOElements, FXA, and Wwisestream StrRefs."/>
         <MenuItem Header="Clone Node and Sequence" Click="CloneNodeAndSequence_Click" ToolTip="Clones a dialogue node along with its linked sequence, and give it a unique ID."/>
+        <MenuItem Header="Link Nodes to Free ExportIDs" Click="LinkNodesFree_Click" ToolTip="Links all audio nodes in the conversation without an ExportID to the free ConvNodes in the sequence."/>
+        <MenuItem Header="Link Nodes to ExportIDs by String Reference" Click="LinkNodesStrRef_Click" ToolTip="Links all audio nodes in the conversation without an ExportID to the free ConvNodes that have a matching StringRef in the sequence."/>
+        <MenuItem Header="Batch Create Sequence Elements for Conversation" Click="BatchCreateNodesSequence_Click" ToolTip="Create the basic sequence elements for all nodes that don't have one."/>
+        <MenuItem Header="Create Sequence Elements for Selected Node" Click="CreateNodeSequence_Click" ToolTip="Create the basic sequence objects for the selected audio node, if it doesn't have an ExportID."/>
+        <MenuItem Header="Batch Update VOElements and Interp Comment of Conversation" Click="BatchUpdateVOsAndComments_Click" ToolTip="Update all the Interp comments and VOElements' StrRefIDs that are linked to the audio nodes of the conversation."/>
+        <MenuItem Header="Update VOElements and Interp Comment for Selected Node" Click="UpdateVOAndComment_Click" ToolTip="Update the Interp comment and VOElement' StrRefID that are linked to the selected audio node."/>
+        <MenuItem Header="Batch Add Conversation Defaults to Conversation" Click="BatchAddConversationDefaults_Click" ToolTip="Add a Conversation group, VOElements and SwitchCamera tracks to all audio nodes in the conversation."/>
+        <MenuItem Header="Add Conversation Defaults to Selected Node" Click="AddConversationDefaults_Click" ToolTip="Add a Conversation group, VOElements and SwitchCamera tracks to the selected node."/>
+        <MenuItem Header="Batch Update the InterpLengths of the Conversation" Click="BatchUpdateInterpLengths_Click" ToolTip="Update the InterpLength of all the audio nodes in the conversation, based either on the FXA or the audio length."/>
+        <MenuItem Header="Update the InterpLengths of Selected Node" Click="UpdateInterpLength_Click" ToolTip="Update the InterpLength of the selected audio node, based either on the FXA or the audio length."/>
+        <MenuItem Header="Batch Generate LE1 Audio Links for Conversation" Click="BatchGenerateLE1AudioLinks_Click" ToolTip="Create SoundCues and SoundNodeWaves, and link them to the FaceFX for all audio nodes that don't have one."/>
+        <MenuItem Header="Generate LE1 Audio Links for Selected Node" Click="GenerateLE1AudioLinks_Click" ToolTip="Create SoundCues and SoundNodeWaves, and link them to the FaceFX for the selected audio node."/>
+        <MenuItem Header="Fix Autocontinues" Click="FixAutocontinues_Click" ToolTip="Assign ExportIDs and TLK refs to Autocontinues."/>
+        <MenuItem Header="Batch unlist Track from Group" Click="BatchUnlistTrackFromGroup_Click" ToolTip="Remove the given InterpTrack from all matching InterpGroups in the conversation's InterpDatas."/>
+        <MenuItem Header="Unlist Track from Group" Click="UnlistTrackFromGroup_Click" ToolTip="Remove the given InterpTrack from the matching InterpGroup in the selected node's InterpDatas."/>
     </MenuItem>
 </MenuItem>

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Dialogue Editor/DialogueEditorExperiments/DialogueExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Dialogue Editor/DialogueEditorExperiments/DialogueExperimentsMenuControl.xaml.cs
@@ -30,9 +30,9 @@ namespace LegendaryExplorer.Tools.Dialogue_Editor.DialogueEditorExperiments
 
         // EXPERIMENTS: EXKYWOR------------------------------------------------------------
         #region Exkywor's experiments
-        private void UpdateNativeNodeStringRef_Click(object sender, RoutedEventArgs e)
+        private void UpdateAudioNodeStrRef_Click(object sender, RoutedEventArgs e)
         {
-            DialogueEditorExperimentsE.UpdateNativeNodeStringRef(GetDEWindow());
+            DialogueEditorExperimentsE.UpdateAudioNodeStrRef(GetDEWindow());
         }
 
         private void CloneNodeAndSequence_Click(object sender, RoutedEventArgs e)
@@ -40,7 +40,80 @@ namespace LegendaryExplorer.Tools.Dialogue_Editor.DialogueEditorExperiments
             DialogueEditorExperimentsE.CloneNodeAndSequence(GetDEWindow());
         }
 
-        #endregion
+        private void LinkNodesFree_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.LinkNodesFree(GetDEWindow());
+        }
 
+        private void LinkNodesStrRef_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.LinkNodesStrRef(GetDEWindow());
+        }
+
+        private void BatchCreateNodesSequence_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.BatchCreateNodesSequenceExperiment(GetDEWindow());
+        }
+
+        private void CreateNodeSequence_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.CreateNodeSequenceExperiment(GetDEWindow());
+        }
+
+        private void BatchUpdateVOsAndComments_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.BatchUpdateVOsAndCommentsExperiment(GetDEWindow());
+        }
+        
+        private void UpdateVOAndComment_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.UpdateVOAndCommentExperiment(GetDEWindow());
+        }
+
+        private void BatchAddConversationDefaults_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.BatchAddConversationDefaultsExperiment(GetDEWindow());
+        }
+
+        private void AddConversationDefaults_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.AddConversationDefaultsExperiment(GetDEWindow());
+        }
+
+        private void BatchUpdateInterpLengths_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.BatchUpdateInterpLengthsExperiment(GetDEWindow());
+        }
+
+        private void UpdateInterpLength_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.UpdateInterpLengthExperiment(GetDEWindow());
+        }
+
+        private void BatchGenerateLE1AudioLinks_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.BatchGenerateLE1AudioLinksExperiment(GetDEWindow());
+        }
+
+        private void GenerateLE1AudioLinks_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.GenerateLE1AudioLinksExperiment(GetDEWindow());
+        }
+
+        private void FixAutocontinues_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.FixAutocontinues(GetDEWindow());
+        }
+
+        private void BatchUnlistTrackFromGroup_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.BatchUnlistTrackFromGroupExperiment(GetDEWindow());
+        }
+        
+        private void UnlistTrackFromGroup_Click(object sender, RoutedEventArgs e)
+        {
+            DialogueEditorExperimentsE.UnlistTrackFromGroupExperiment(GetDEWindow());
+        }
+        #endregion
     }
 }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/InterpEditor/InterpExperiments/InterpEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/InterpEditor/InterpExperiments/InterpEditorExperimentsE.cs
@@ -1,7 +1,13 @@
-﻿using System.Windows;
-using LegendaryExplorer.Dialogs;
+﻿using LegendaryExplorer.Dialogs;
 using LegendaryExplorerCore.Matinee;
 using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Unreal;
+using LegendaryExplorerCore.Unreal.ObjectInfo;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using static LegendaryExplorer.Misc.ExperimentsTools.SharedMethods;
 
 namespace LegendaryExplorer.Tools.InterpEditor.InterpExperiments
 {
@@ -10,6 +16,437 @@ namespace LegendaryExplorer.Tools.InterpEditor.InterpExperiments
     /// </summary>
     class InterpEditorExperimentsE
     {
+        /// <summary>
+        /// Wrapper for InsertTrackMoveKey.
+        /// </summary>
+        /// <param name="iew">Current IE window.</param>
+        public static void InsertTrackMoveKeyExperiment(InterpEditorWindow iew)
+        {
+            if (iew.Pcc == null || iew.Properties_InterpreterWPF == null || iew.Properties_InterpreterWPF.CurrentLoadedExport == null) { return; }
+
+            ExportEntry trackMove = iew.Properties_InterpreterWPF.CurrentLoadedExport;
+
+            if (trackMove.ClassName is not "InterpTrackMove")
+            {
+                MessageBox.Show("Selected export is not an InterpTrackMove", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            // Gather all the values from the user
+            string moveVals = PromptDialog.Prompt(null,
+                "Write the x,y,z position values, the x(roll),y(pitch),z(yaw) rotation values, and the time at which to set the movement in the following form:\n" +
+                "posX,posY,posZ;rotX,rotY,rotZ;time\n\n" +
+                "Use periods for decimals, not commas."
+                );
+            if (string.IsNullOrEmpty(moveVals))
+            {
+                MessageBox.Show("Invalid movement values", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string[] moveValsArr = moveVals.Trim().Split(";");
+            if (moveValsArr.Length != 3)
+            {
+                MessageBox.Show("Did not provide one of the pos, rot, or time values.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string[] posArrAsStr = moveValsArr[0].Trim().Split(",");
+            if (posArrAsStr.Length != 3)
+            {
+                MessageBox.Show("Did not provide one of the X, Y, or Z position values.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            List<float> posArr = new();
+            foreach (string val in posArrAsStr)
+            {
+                if (!float.TryParse(val.Trim(), out float f))
+                {
+                    MessageBox.Show($"Error parsing the value \"{val.Trim()}\" for the position.", "Warning", MessageBoxButton.OK);
+                    return;
+                }
+                posArr.Add(f);
+            }
+
+            string[] rotArrAsStr = moveValsArr[1].Trim().Split(",");
+            if (rotArrAsStr.Length != 3)
+            {
+                MessageBox.Show("Did not provide one of the X, Y, or Z rotation values.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            List<float> rotArr = new();
+            foreach (string val in rotArrAsStr)
+            {
+                if (!float.TryParse(val.Trim(), out float f))
+                {
+                    MessageBox.Show($"Error parsing the value \"{val.Trim()}\" for the rotation.", "Warning", MessageBoxButton.OK);
+                    return;
+                }
+                rotArr.Add(f);
+            }
+
+            string timeStr = moveValsArr[2].Trim();
+            if (!float.TryParse(timeStr, out float time))
+            {
+                MessageBox.Show("Error parsing the time.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            InsertTrackMoveKey(trackMove, posArr, rotArr, time);
+
+            MessageBox.Show($"Keys at {moveVals.Trim()} successfully added", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Inserts a position, rotation, and time keys to the InterpTrackMove at the specified index.
+        /// </summary>
+        /// <param name="trackMove">InterpTrackMove to operate on.</param>
+        /// <param name="posArr">Position values array.</param>
+        /// <param name="rotArr">Rotation values array.</param>
+        /// <param name="time">Time to set the keys at.</param>
+        private static void InsertTrackMoveKey(ExportEntry trackMove, List<float> posArr, List<float> rotArr, float time)
+        {
+            IMEPackage pcc = trackMove.FileRef;
+
+            PropertyCollection props = trackMove.GetProperties();
+            StructProperty posTrack = props.GetProp<StructProperty>("PosTrack");
+            StructProperty eulerTrack = props.GetProp<StructProperty>("EulerTrack");
+            StructProperty lookupTrack = props.GetProp<StructProperty>("LookupTrack");
+
+            if (posTrack == null || eulerTrack == null || lookupTrack == null)
+            {
+                MessageBox.Show("The TrackMove is missing one of the three array properties.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            int insertIdx = GetIndexByTime(lookupTrack.GetProp<ArrayProperty<StructProperty>>("Points"), time, trackMove.ClassName);
+
+            StructProperty posProp = GenerateArrayStructProp(pcc.Game, "Points", "InterpCurveVector");
+            posProp.GetProp<FloatProperty>("InVal").Value = time;
+            StructProperty outVal = posProp.GetProp<StructProperty>("OutVal");
+            outVal.GetProp<FloatProperty>("X").Value = posArr[0];
+            outVal.GetProp<FloatProperty>("Y").Value = posArr[1];
+            outVal.GetProp<FloatProperty>("Z").Value = posArr[2];
+            posTrack.GetProp<ArrayProperty<StructProperty>>("Points").Insert(insertIdx, posProp);
+
+            StructProperty eulerProp = GenerateArrayStructProp(pcc.Game, "Points", "InterpCurveVector");
+            eulerProp.GetProp<FloatProperty>("InVal").Value = time;
+            outVal = eulerProp.GetProp<StructProperty>("OutVal");
+            outVal.GetProp<FloatProperty>("X").Value = rotArr[0];
+            outVal.GetProp<FloatProperty>("Y").Value = rotArr[1];
+            outVal.GetProp<FloatProperty>("Z").Value = rotArr[2];
+            eulerTrack.GetProp<ArrayProperty<StructProperty>>("Points").Insert(insertIdx, eulerProp);
+
+            StructProperty lookupProp = GenerateArrayStructProp(pcc.Game, "Points", "InterpLookupTrack");
+            lookupProp.GetProp<FloatProperty>("Time").Value = time;
+            lookupTrack.GetProp<ArrayProperty<StructProperty>>("Points").Insert(insertIdx, lookupProp);
+
+            trackMove.WriteProperties(props);
+        }
+
+        /// <summary>
+        /// Deletes the position, rotation, and time keys of the InterpTrackMove at the specific index.
+        /// </summary>
+        /// <param name="iew">Current IE window.</param>
+        public static void DeleteTrackMoveKey(InterpEditorWindow iew)
+        {
+            if (iew.Pcc == null || iew.Properties_InterpreterWPF == null || iew.Properties_InterpreterWPF.CurrentLoadedExport == null) { return; }
+
+            ExportEntry trackMove = iew.Properties_InterpreterWPF.CurrentLoadedExport;
+
+            if (trackMove.ClassName is not "InterpTrackMove")
+            {
+                MessageBox.Show("Selected export is not an InterpTrackMove", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            int idx = PromptForInt("Provide the 0-based index of the key to remove.", "Invalid index", -1);
+            if (idx == -1) { return; }
+
+            PropertyCollection props = trackMove.GetProperties();
+            StructProperty posTrack = props.GetProp<StructProperty>("PosTrack");
+            StructProperty eulerTrack = props.GetProp<StructProperty>("EulerTrack");
+            StructProperty lookupTrack = props.GetProp<StructProperty>("LookupTrack");
+
+            if (posTrack == null || eulerTrack == null || lookupTrack == null)
+            {
+                MessageBox.Show("The TrackMove is missing one of the three array properties.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            try
+            {
+                posTrack.GetProp<ArrayProperty<StructProperty>>("Points").RemoveAt(idx);
+                eulerTrack.GetProp<ArrayProperty<StructProperty>>("Points").RemoveAt(idx);
+                lookupTrack.GetProp<ArrayProperty<StructProperty>>("Points").RemoveAt(idx);
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show($"{e.Message}", "Error", MessageBoxButton.OK);
+                return;
+            }
+
+            trackMove.WriteProperties(props);
+
+            MessageBox.Show($"Keys {idx} successfully deleted", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Inserts a DOF and time keys to the DOF track at the specified index.
+        /// </summary>
+        /// <param name="iew">Current IE window.</param>
+        public static void InsertDOFKey(InterpEditorWindow iew)
+        {
+            if (iew.Pcc == null || iew.Properties_InterpreterWPF == null || iew.Properties_InterpreterWPF.CurrentLoadedExport == null) { return; }
+
+            ExportEntry dofTrack = iew.Properties_InterpreterWPF.CurrentLoadedExport;
+
+            if (dofTrack.ClassName is not "BioEvtSysTrackDOF")
+            {
+                MessageBox.Show("Selected export is not an BioEvtSysTrackDOF", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            // Gather all the values from the user
+            string dofVals = PromptDialog.Prompt(null,
+                "Write the DOF inner radius, the focus distance, and the time at which to set it in the following form:\n" +
+                "innerRadius;focusDistance;time\n\n" +
+                "Use periods for decimals, not commas."
+                );
+            if (string.IsNullOrEmpty(dofVals))
+            {
+                MessageBox.Show("Invalid DOF values", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string[] dofValsArr = dofVals.Trim().Split(";");
+            if (dofValsArr.Length != 3)
+            {
+                MessageBox.Show("Did not provide one of the inner radius, focus distance, or time values.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            if (!float.TryParse(dofValsArr[0].Trim(), out float innerRadius))
+            {
+                MessageBox.Show($"Error parsing the inner radius.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            if (!float.TryParse(dofValsArr[1].Trim(), out float focusDistance))
+            {
+                MessageBox.Show($"Error parsing the focus distance.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            if (!float.TryParse(dofValsArr[2].Trim(), out float time))
+            {
+                MessageBox.Show("Error parsing the time.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            PropertyCollection props = dofTrack.GetProperties();
+            ArrayProperty<StructProperty> m_aDOFData = props.GetProp<ArrayProperty<StructProperty>>("m_aDOFData");
+            ArrayProperty<StructProperty> m_aTrackKeys = props.GetProp<ArrayProperty<StructProperty>>("m_aTrackKeys");
+
+            if (m_aDOFData == null || m_aTrackKeys == null)
+            {
+                MessageBox.Show("The DOF track is missing either the DOFData or TrackKeys array properties.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            int insertIdx = GetIndexByTime(m_aTrackKeys, time, dofTrack.ClassName);
+
+            StructProperty dofProp = GenerateArrayStructProp(iew.Pcc.Game, "m_aDOFData", "BioEvtSysTrackDOF");
+            dofProp.GetProp<FloatProperty>("fFocusInnerRadius").Value = innerRadius;
+            dofProp.GetProp<FloatProperty>("fFocusDistance").Value = focusDistance;
+            dofProp.GetProp<BoolProperty>("bEnableDOF").Value = true;
+            m_aDOFData.Insert(insertIdx, dofProp);
+
+            StructProperty timeProp = GenerateArrayStructProp(iew.Pcc.Game, "m_aTrackKeys", "BioEvtSysTrackDOF");
+            timeProp.GetProp<FloatProperty>("fTime").Value = time;
+            m_aTrackKeys.Insert(insertIdx, timeProp);
+
+            dofTrack.WriteProperties(props);
+
+            MessageBox.Show($"Keys at {dofVals.Trim()} successfully added", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Deletes the DOF and time keys of the DOF track at specific index.
+        /// </summary>
+        /// <param name="iew">Current IE window.</param>
+        public static void DeleteDOFKey(InterpEditorWindow iew)
+        {
+            if (iew.Pcc == null || iew.Properties_InterpreterWPF == null || iew.Properties_InterpreterWPF.CurrentLoadedExport == null) { return; }
+
+            ExportEntry dofTrack = iew.Properties_InterpreterWPF.CurrentLoadedExport;
+
+            if (dofTrack.ClassName is not "BioEvtSysTrackDOF")
+            {
+                MessageBox.Show("Selected export is not an BioEvtSysTrackDOF", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            int idx = PromptForInt("Provide the 0-based index of the key to remove.", "Invalid index", -1);
+            if (idx == -1) { return; }
+
+            PropertyCollection props = dofTrack.GetProperties();
+            ArrayProperty<StructProperty> m_aDOFData = props.GetProp<ArrayProperty<StructProperty>>("m_aDOFData");
+            ArrayProperty<StructProperty> m_aTrackKeys = props.GetProp<ArrayProperty<StructProperty>>("m_aTrackKeys");
+
+            if (m_aDOFData == null || m_aTrackKeys == null)
+            {
+                MessageBox.Show("The DOF track is missing either the DOFData or TrackKeys array properties.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            try
+            {
+                m_aDOFData.RemoveAt(idx);
+                m_aTrackKeys.RemoveAt(idx);
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show($"{e.Message}", "Error", MessageBoxButton.OK);
+                return;
+            }
+
+            dofTrack.WriteProperties(props);
+
+            MessageBox.Show($"Keys {idx} successfully deleted", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Inserts a Gesture and time keys to the Gesture track at the specified index.
+        /// </summary>
+        /// <param name="iew">Current IE window.</param>
+        public static void InsertGestureKey(InterpEditorWindow iew)
+        {
+            if (iew.Pcc == null || iew.Properties_InterpreterWPF == null || iew.Properties_InterpreterWPF.CurrentLoadedExport == null) { return; }
+
+            ExportEntry trackGesture = iew.Properties_InterpreterWPF.CurrentLoadedExport;
+
+            if (trackGesture.ClassName is not "BioEvtSysTrackGesture")
+            {
+                MessageBox.Show("Selected export is not an BioEvtSysTrackGesture", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            float time = PromptForFloat("Time to insert the key at:", "Not a valid time.", "Time key");
+
+            PropertyCollection props = trackGesture.GetProperties();
+            ArrayProperty<StructProperty> m_aGestures = props.GetProp<ArrayProperty<StructProperty>>("m_aGestures");
+            ArrayProperty<StructProperty> m_aTrackKeys = props.GetProp<ArrayProperty<StructProperty>>("m_aTrackKeys");
+
+            if (m_aGestures == null || m_aTrackKeys == null)
+            {
+                MessageBox.Show("The Gestures track is missing either the Gestures or TrackKeys array properties.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            int insertIdx = GetIndexByTime(m_aTrackKeys, time, trackGesture.ClassName);
+
+            StructProperty gestureProp = GenerateArrayStructProp(iew.Pcc.Game, "m_aGestures", "BioEvtSysTrackGesture");
+            m_aGestures.Insert(insertIdx, gestureProp);
+
+            StructProperty timeProp = GenerateArrayStructProp(iew.Pcc.Game, "m_aTrackKeys", "BioEvtSysTrackGesture");
+            timeProp.GetProp<FloatProperty>("fTime").Value = time;
+            m_aTrackKeys.Insert(insertIdx, timeProp);
+
+            trackGesture.WriteProperties(props);
+
+            MessageBox.Show($"Keys at {time} successfully added", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Deletes the Gesture and time keys of the Gesture track at specific index.
+        /// </summary>
+        /// <param name="iew">Current IE window.</param>
+        public static void DeleteGestureKey(InterpEditorWindow iew)
+        {
+            if (iew.Pcc == null || iew.Properties_InterpreterWPF == null || iew.Properties_InterpreterWPF.CurrentLoadedExport == null) { return; }
+
+            ExportEntry gesturesTrack = iew.Properties_InterpreterWPF.CurrentLoadedExport;
+
+            if (gesturesTrack.ClassName is not "BioEvtSysTrackGesture")
+            {
+                MessageBox.Show("Selected export is not an BioEvtSysTrackGesture", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            int idx = PromptForInt("Provide the 0-based index of the key to remove.", "Invalid index", -1);
+            if (idx == -1) { return; }
+
+            PropertyCollection props = gesturesTrack.GetProperties();
+            ArrayProperty<StructProperty> m_aGestures = props.GetProp<ArrayProperty<StructProperty>>("m_aGestures");
+            ArrayProperty<StructProperty> m_aTrackKeys = props.GetProp<ArrayProperty<StructProperty>>("m_aTrackKeys");
+
+            if (m_aGestures == null || m_aTrackKeys == null)
+            {
+                MessageBox.Show("The Gestures track is missing either the Gestures or TrackKeys array properties.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            try
+            {
+                m_aGestures.RemoveAt(idx);
+                m_aTrackKeys.RemoveAt(idx);
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show($"{e.Message}", "Error", MessageBoxButton.OK);
+                return;
+            }
+
+            gesturesTrack.WriteProperties(props);
+
+            MessageBox.Show($"Keys {idx} successfully deleted", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Generate a StructProperty to add to an array.
+        /// </summary>
+        /// <param name="game">Game the pcc is of.</param>
+        /// <param name="parentName">Name of the parent to add the struct to.</param>
+        /// <param name="containingType">Classname of the struct.</param>
+        /// <returns>Generated StructProperty</returns>
+        private static StructProperty GenerateArrayStructProp(MEGame game, string parentName, string containingType)
+        {
+            PropertyInfo p = GlobalUnrealObjectInfo.GetPropertyInfo(game, parentName, containingType);
+            string typeName = p.Reference;
+            PropertyCollection props = GlobalUnrealObjectInfo.getDefaultStructValue(game, typeName, true);
+            return new StructProperty(typeName, props, isImmutable: GlobalUnrealObjectInfo.IsImmutable(typeName, game));
+        }
+
+        /// <summary>
+        /// Get the index at which to insert a key so that it's inserted before the next element in the timeline.
+        /// </summary>
+        /// <param name="arr">Array to find the index in.</param>
+        /// <param name="time">Time ot find the index of.</param>
+        /// <param name="className">Track's class name.</param>
+        /// <returns>The index at which to insert the key.</returns>
+        private static int GetIndexByTime(ArrayProperty<StructProperty> arr, float time, string className)
+        {
+            int idx = 0;
+
+            for (int i = 0; i < arr.Count; i++)
+            {
+                StructProperty prop = arr[i];
+                FloatProperty timeProp = prop.GetProp<FloatProperty>($"{(className == "InterpTrackMove" ? "Time" : "fTime")}");
+
+                if (time > timeProp.Value) { idx = i + 1; }
+                else
+                {
+                    idx = i;
+                    break;
+                }
+            }
+
+            return idx;
+        }
+
         public static void AddPresetGroup(string preset, InterpEditorWindow iew)
         {
             var currExp = iew.Properties_InterpreterWPF.CurrentLoadedExport;
@@ -37,7 +474,7 @@ namespace LegendaryExplorer.Tools.InterpEditor.InterpExperiments
                         break;
 
                     case "Camera":
-                        var camActor = promptForActor("Name of camera actor:", "Not a valid camera actor name.");
+                        var camActor = PromptForStr("Name of camera actor:", "Not a valid camera actor name.");
                         if (!string.IsNullOrEmpty(camActor))
                         {
                             MatineeHelper.AddPreset(preset, currExp, game, camActor);
@@ -45,7 +482,7 @@ namespace LegendaryExplorer.Tools.InterpEditor.InterpExperiments
                         break;
 
                     case "Actor":
-                        var actActor = promptForActor("Name of actor:", "Not a valid actor name.");
+                        var actActor = PromptForStr("Name of actor:", "Not a valid actor name.");
                         if (!string.IsNullOrEmpty(actActor))
                         {
                             MatineeHelper.AddPreset(preset, currExp, game, actActor);
@@ -80,7 +517,7 @@ namespace LegendaryExplorer.Tools.InterpEditor.InterpExperiments
                 {
                     case "Gesture":
                     case "Gesture2":
-                        var actor = promptForActor("Name of gesture actor:", "Not a valid gesture actor name.");
+                        var actor = PromptForStr("Name of gesture actor:", "Not a valid gesture actor name.");
                         if (!string.IsNullOrEmpty(actor))
                         {
                             MatineeHelper.AddPreset(preset, currExp, game, actor);
@@ -91,18 +528,158 @@ namespace LegendaryExplorer.Tools.InterpEditor.InterpExperiments
             return;
         }
 
-        private static string promptForActor(string msg, string err)
+        /// <summary>
+        /// Add a Camera InterpGroup with its actor set along with Move and FOV tracks, and inserting a position, rotation, and time keys to its Move track.
+        /// </summary>
+        /// <param name="iew">Current IE window.</param>
+        public static void AddPresetCameraWithKeys(InterpEditorWindow iew)
         {
-            if (PromptDialog.Prompt(null, msg) is string actor)
+            if (iew.Pcc == null || iew.Properties_InterpreterWPF == null || iew.Properties_InterpreterWPF.CurrentLoadedExport == null) { return; }
+
+            if (iew.Pcc.Game.IsGame1())
             {
-                if (string.IsNullOrEmpty(actor))
-                {
-                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
-                    return null;
-                }
-                return actor;
+                MessageBox.Show("This experiment is not available for ME1/LE1 files.", "Warning", MessageBoxButton.OK);
+                return;
             }
-            return null;
+
+            if (iew.Properties_InterpreterWPF.CurrentLoadedExport.ClassName is not "InterpData")
+            {
+                MessageBox.Show("Selected export is not an InterpData", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string camActor = PromptForStr("Name of camera actor:", "Not a valid camera actor name.");
+
+            ExportEntry group = MatineeHelper.AddPreset("Camera", iew.Properties_InterpreterWPF.CurrentLoadedExport, iew.Pcc.Game, camActor);
+
+            MatineeHelper.TryGetInterpTrack(group, "InterpTrackMove", out ExportEntry trackMove);
+
+            // Gather all the values from the user
+            string moveVals = PromptDialog.Prompt(null,
+                "Write the x,y,z position values, the x(roll),y(pitch),z(yaw) rotation values, and the time at which to set the movement in the following form:\n" +
+                "posX,posY,posZ;rotX,rotY,rotZ;time\n\n" +
+                "Use periods for decimals, not commas."
+                );
+            if (string.IsNullOrEmpty(moveVals))
+            {
+                MessageBox.Show("Invalid movement values", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string[] moveValsArr = moveVals.Trim().Split(";");
+            if (moveValsArr.Length != 3)
+            {
+                MessageBox.Show("Did not provide one of the pos, rot, or time values.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string[] posArrAsStr = moveValsArr[0].Trim().Split(",");
+            if (posArrAsStr.Length != 3)
+            {
+                MessageBox.Show("Did not provide one of the X, Y, or Z position values.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            List<float> posArr = new();
+            foreach (string val in posArrAsStr)
+            {
+                if (!float.TryParse(val.Trim(), out float f))
+                {
+                    MessageBox.Show($"Error parsing the value \"{val.Trim()}\" for the position.", "Warning", MessageBoxButton.OK);
+                    return;
+                }
+                posArr.Add(f);
+            }
+
+            string[] rotArrAsStr = moveValsArr[1].Trim().Split(",");
+            if (rotArrAsStr.Length != 3)
+            {
+                MessageBox.Show("Did not provide one of the X, Y, or Z rotation values.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            List<float> rotArr = new();
+            foreach (string val in rotArrAsStr)
+            {
+                if (!float.TryParse(val.Trim(), out float f))
+                {
+                    MessageBox.Show($"Error parsing the value \"{val.Trim()}\" for the rotation.", "Warning", MessageBoxButton.OK);
+                    return;
+                }
+                rotArr.Add(f);
+            }
+
+            string timeStr = moveValsArr[2].Trim();
+            if (!float.TryParse(timeStr, out float time))
+            {
+                MessageBox.Show("Error parsing the time.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            InsertTrackMoveKey(trackMove, posArr, rotArr, time);
+
+            MessageBox.Show($"Added actor preset InterpGroup with the provided move keys.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Provided a full animation name, set the starting pose set, animation, and offset for the selected gesture track.
+        /// </summary>
+        /// <param name="iew">Current IE window.</param>
+        public static void SetStartingPose(InterpEditorWindow iew)
+        {
+            if (iew.Pcc == null || iew.Properties_InterpreterWPF == null || iew.Properties_InterpreterWPF.CurrentLoadedExport == null) { return; }
+
+            ExportEntry trackGesture = iew.Properties_InterpreterWPF.CurrentLoadedExport;
+
+            if (trackGesture.ClassName is not "BioEvtSysTrackGesture")
+            {
+                MessageBox.Show("Selected export is not an BioEvtSysTrackGesture", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string prompt = PromptForStr("StartingPoseSet, StartingPoseAnim, and StartPoseOffset separated by a semi-colon:", "Invalid animation.");
+
+            string[] promptArr = prompt.Trim().Split(";");
+
+            if (promptArr.Length != 3)
+            {
+                MessageBox.Show("Did not provide the required values.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            string startingPoseSet = promptArr[0].Trim();
+            if (string.IsNullOrEmpty(startingPoseSet))
+            {
+                MessageBox.Show("Invalid StartingPoseSet.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+            string startingPoseAnim = promptArr[1].Trim();
+            if (string.IsNullOrEmpty(startingPoseAnim))
+            {
+                MessageBox.Show("Invalid StartingPoseAnim.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            if (!float.TryParse(promptArr[2], out float offset))
+            {
+                MessageBox.Show("Invalid StartPoseOffset.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            if (!iew.Pcc.Names.Contains($"{startingPoseSet}_{startingPoseAnim}"))
+            {
+                MessageBox.Show("The provided animation does not exist in the current package.", "Warning", MessageBoxButton.OK);
+                return;
+            }
+
+            PropertyCollection props = trackGesture.GetProperties();
+            props.AddOrReplaceProp(new NameProperty(startingPoseSet, "nmStartingPoseSet"));
+            props.AddOrReplaceProp(new NameProperty(startingPoseAnim, "nmStartingPoseAnim"));
+            props.AddOrReplaceProp(new FloatProperty(offset, "m_fStartPoseOffset"));
+
+            trackGesture.WriteProperties(props);
+
+            MessageBox.Show($"Successfully set the starting pose.", "Success", MessageBoxButton.OK);
         }
     }
 }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/InterpEditor/InterpExperiments/InterpExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/InterpEditor/InterpExperiments/InterpExperimentsMenuControl.xaml
@@ -20,10 +20,18 @@
         <MenuItem Header="(FOVO) Open Line in Dialogue Editor" Click="OpenFovoLineDlg_Click" Tag="F" ToolTip="Opens the selected FOVO line in Dialogue Editor"/>
     </MenuItem>
     <MenuItem Header="Exkywor's buttons for lazy people">
+        <MenuItem Header="Insert TrackMove Key" Click="InsertTrackMoveKey_Click" ToolTip="Inserts a position, rotation, and time keys to the InterpTrackMove."/>
+        <MenuItem Header="Delete TrackMove Key" Click="DeleteTrackMoveKey_Click" ToolTip="Deletes the position, rotation, and time keys of the InterpTrackMove at the specific index."/>
+        <MenuItem Header="Insert DOF Key" Click="InsertDOFKey_Click" ToolTip="Inserts a DOF and time keys to the DOF track."/>
+        <MenuItem Header="Delete DOF Key" Click="DeleteDOFKey_Click" ToolTip="Deletes the DOF and time keys of the DOF track at specific index."/>
+        <MenuItem Header="Insert Gesture Key" Click="InsertGestureKey_Click" ToolTip="Inserts a Gesture and time keys to the Gesture track."/>
+        <MenuItem Header="Delete Gesture Key" Click="DeleteGestureKey_Click" ToolTip="Deletes the Gesture and time keys of the Gesture track at specific index."/>
         <MenuItem Header="Add Preset Director InterpGroup" Click="AddPresetDirectorGroup_Click" ToolTip="Add an InterpGroupDirector along with Director and DOF tracks."/>
         <MenuItem Header="Add Preset Camera InterpGroup" Click="AddPresetCameraGroup_Click" ToolTip="Add a Camera InterpGroup with its actor set along with Move and FOV tracks."/>
+        <MenuItem Header="Add Preset Camera InterpGroup with TrackMove Keys" Click="AddPresetCameraGroupWithKeys_Click" ToolTip="Add a Camera InterpGroup with its actor set along with Move and FOV tracks, and inserting a position, rotation, and time keys to its Move track."/>
         <MenuItem Header="Add Preset Actor InterpGroup" Click="AddPresetActorGroup_Click" ToolTip="Add an Actor InterpGroup with its actor set along with Move and Gesture tracks, as designed by Mentlegen."/>
         <MenuItem Header="Add Preset Gesture Track" Click="AddPresetGestureTrack_Click" ToolTip="Add a Gesture track with its actor set along with all the default properties."/>
         <MenuItem Header="Add Preset Gesture Track 2" Click="AddPresetGestureTrack2_Click" ToolTip="Alternate version of preset Gesture track, as designed by Lunk."/>
+        <MenuItem Header="Set Starting Pose" Click="SetStartingPose_Click" ToolTip="Provided a full animation name, set the starting pose set, animation, and offset for the selected gesture track."/>
     </MenuItem>
 </MenuItem>

--- a/LegendaryExplorer/LegendaryExplorer/Tools/InterpEditor/InterpExperiments/InterpExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/InterpEditor/InterpExperiments/InterpExperimentsMenuControl.xaml.cs
@@ -28,6 +28,31 @@ namespace LegendaryExplorer.Tools.InterpEditor.InterpExperiments
 
         // EXPERIMENTS: EXKYWOR------------------------------------------------------------
         #region Exkywor's experiments
+        private void InsertTrackMoveKey_Click(object sender, RoutedEventArgs e)
+        {
+            InterpEditorExperimentsE.InsertTrackMoveKeyExperiment(GetIEWindow());
+        }
+        private void DeleteTrackMoveKey_Click(object sender, RoutedEventArgs e)
+        {
+            InterpEditorExperimentsE.DeleteTrackMoveKey(GetIEWindow());
+        }
+        private void InsertDOFKey_Click(object sender, RoutedEventArgs e)
+        {
+            InterpEditorExperimentsE.InsertDOFKey(GetIEWindow());
+        }
+        private void DeleteDOFKey_Click(object sender, RoutedEventArgs e)
+        {
+            InterpEditorExperimentsE.DeleteDOFKey(GetIEWindow());
+        }
+        private void InsertGestureKey_Click(object sender, RoutedEventArgs e)
+        {
+            InterpEditorExperimentsE.InsertGestureKey(GetIEWindow());
+        }
+        private void DeleteGestureKey_Click(object sender, RoutedEventArgs e)
+        {
+            InterpEditorExperimentsE.DeleteGestureKey(GetIEWindow());
+        }
+
         private void AddPresetDirectorGroup_Click(object sender, RoutedEventArgs e)
         {
             InterpEditorExperimentsE.AddPresetGroup("Director", GetIEWindow());
@@ -36,6 +61,10 @@ namespace LegendaryExplorer.Tools.InterpEditor.InterpExperiments
         private void AddPresetCameraGroup_Click(object sender, RoutedEventArgs e)
         {
             InterpEditorExperimentsE.AddPresetGroup("Camera", GetIEWindow());
+        }
+        private void AddPresetCameraGroupWithKeys_Click(object sender, RoutedEventArgs e)
+        {
+            InterpEditorExperimentsE.AddPresetCameraWithKeys(GetIEWindow());
         }
 
         private void AddPresetActorGroup_Click(object sender, RoutedEventArgs e)
@@ -52,6 +81,11 @@ namespace LegendaryExplorer.Tools.InterpEditor.InterpExperiments
         {
             InterpEditorExperimentsE.AddPresetTrack("Gesture2", GetIEWindow());
         }
+
+        private void SetStartingPose_Click(object sender, RoutedEventArgs e)
+        {
+            InterpEditorExperimentsE.SetStartingPose(GetIEWindow());
+        } 
         #endregion
 
         // EXPERIMENTS: HenBagle------------------------------------------------------------

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/Experiments/PackageEditorExperimentsO.cs
@@ -2,20 +2,24 @@
 using LegendaryExplorer.Tools.TlkManagerNS;
 using LegendaryExplorerCore.Dialogue;
 using LegendaryExplorerCore.GameFilesystem;
+using LegendaryExplorerCore.Gammtek.Extensions.Collections.Generic;
 using LegendaryExplorerCore.Helpers;
 using LegendaryExplorerCore.Kismet;
 using LegendaryExplorerCore.Matinee;
 using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Packages.CloningImportingAndRelinking;
+using LegendaryExplorerCore.SharpDX;
 using LegendaryExplorerCore.Unreal;
 using LegendaryExplorerCore.Unreal.BinaryConverters;
-using LegendaryExplorerCore.Unreal.ObjectInfo;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
-using System.Text;
 using System.Windows;
+using static LegendaryExplorer.Misc.ExperimentsTools.PackageAutomations;
+using static LegendaryExplorer.Misc.ExperimentsTools.SequenceAutomations;
+using static LegendaryExplorer.Misc.ExperimentsTools.SharedMethods;
 
 namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 {
@@ -238,7 +242,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                         break;
 
                     case "Camera":
-                        var camActor = promptForActor("Name of camera actor:", "Not a valid camera actor name.");
+                        var camActor = PromptForStr("Name of camera actor:", "Not a valid camera actor name.");
                         if (!string.IsNullOrEmpty(camActor))
                         {
                             MatineeHelper.AddPreset(preset, interp, game, camActor);
@@ -246,7 +250,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                         break;
 
                     case "Actor":
-                        var actActor = promptForActor("Name of actor:", "Not a valid actor name.");
+                        var actActor = PromptForStr("Name of actor:", "Not a valid actor name.");
                         if (!string.IsNullOrEmpty(actActor))
                         {
                             MatineeHelper.AddPreset(preset, interp, game, actActor);
@@ -282,7 +286,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 {
                     case "Gesture":
                     case "Gesture2":
-                        var actor = promptForActor("Name of gesture actor:", "Not a valid gesture actor name.");
+                        var actor = PromptForStr("Name of gesture actor:", "Not a valid gesture actor name.");
                         if (!string.IsNullOrEmpty(actor))
                         {
                             MatineeHelper.AddPreset(preset, interp, game, actor);
@@ -291,20 +295,6 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 }
             }
             return;
-        }
-
-        private static string promptForActor(string msg, string err)
-        {
-            if (PromptDialog.Prompt(null, msg) is string actor)
-            {
-                if (string.IsNullOrEmpty(actor))
-                {
-                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
-                    return null;
-                }
-                return actor;
-            }
-            return null;
         }
 
         /// <summary>
@@ -1097,19 +1087,29 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            int newConvResRefID = promptForInt("New ConvResRefID:", "Not a valid ref id. It must be positive integer", -1, "New ConvResRefID");
+            int newConvResRefID = PromptForInt("New ConvResRefID:", "Not a valid ref id. It must be positive integer", -1, "New ConvResRefID");
             if (newConvResRefID == -1) { return; }
 
-            int convNodeIDBase = promptForInt("New ConvNodeID base range:", "Not a valid base. It must be positive integer", -1, "New NodeID range");
+            int convNodeIDBase = PromptForInt("New ConvNodeID base range:", "Not a valid base. It must be positive integer", -1, "New NodeID range");
             if (convNodeIDBase == -1) { return; }
 
-            bool updateAudioIDs = false;
+            bool updateAllAudioIDs = false;
+            bool updateOnlyWwiseBankID = false;
             if (!pew.Pcc.Game.IsGame1())
             {
-                updateAudioIDs = MessageBoxResult.Yes == MessageBox.Show(
-                "Update the IDs of the WwiseBank?\nIn general it's safe and better to do so, but there may be edge cases" +
-                "where doing so may overwrite parts of the WwiseBank binary that are not the IDs.",
-                "Update WwiseBank ID", MessageBoxButton.YesNo);
+                updateAllAudioIDs = PromptForBool("Update all audio IDs?\n" +
+                    "This will give the give the conversation fully unique IDs," +
+                    "hashing the names for the WwiseBank and Stream IDs, and using random generation for the Event IDs," +
+                    "then doing a blind replacement in the binary of the bank. There is a very small chance it may replace something" +
+                    "it shouldn't, so do this at your own risk.", "Update all audio IDs");
+
+                if (!updateAllAudioIDs)
+                {
+                    updateOnlyWwiseBankID = PromptForBool("Update the ID of the WwiseBank?\n" +
+                        "In general it's safe and better to do so, but there may be edge cases" +
+                        "where doing so may overwrite parts of the WwiseBank binary that are not its ID.",
+                        "Update WwiseBank ID");
+                }
             }
 
             bool bringTrash = MessageBoxResult.No == MessageBox.Show(
@@ -1134,7 +1134,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             }
 
             // Rename the conversation, its package, the FXAs, and the related audio elements
-            string conversationResult = RenameConversation(pew.Pcc, bioConversation, conversation, newName, updateAudioIDs);
+            string conversationResult = RenameConversation(pew.Pcc, bioConversation, conversation, newName, updateAllAudioIDs, updateOnlyWwiseBankID);
             if (!string.IsNullOrEmpty(conversationResult))
             {
                 ShowError(conversationResult);
@@ -1465,10 +1465,10 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            int newConvResRefID = promptForInt("New ConvResRefID:", "Not a valid ref id. It must be positive integer", -1, "New ConvResRefID");
+            int newConvResRefID = PromptForInt("New ConvResRefID:", "Not a valid ref id. It must be positive integer", -1, "New ConvResRefID");
             if (newConvResRefID == -1) { return; }
 
-            int convNodeIDBase = promptForInt("New ConvNodeID base range:", "Not a valid base. It must be positive integer", -1, "New NodeID range");
+            int convNodeIDBase = PromptForInt("New ConvNodeID base range:", "Not a valid base. It must be positive integer", -1, "New NodeID range");
             if (convNodeIDBase == -1) { return; }
 
             ExportEntry bioConversation = (ExportEntry)pew.SelectedItem.Entry;
@@ -1598,13 +1598,23 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            bool updateAudioIDs = false;
+            bool updateAllAudioIDs = false;
+            bool updateOnlyWwiseBankID = false;
             if (!pew.Pcc.Game.IsGame1())
             {
-                updateAudioIDs = MessageBoxResult.Yes == MessageBox.Show(
-                "Update the IDs of the WwiseBank?\nIn general it's safe and better to do so, but there may be edge cases" +
-                "where doing so may overwrite parts of the WwiseBank binary that are not the IDs.",
-                "Update WwiseBank ID", MessageBoxButton.YesNo);
+                updateAllAudioIDs = PromptForBool("Update all audio IDs?\n" +
+                    "This will give the give the conversation fully unique IDs," +
+                    "hashing the names for the WwiseBank and Stream IDs, and using random generation for the Event IDs," +
+                    "then doing a blind replacement in the binary of the bank. There is a very small chance it may replace something" +
+                    "it shouldn't, so do this at your own risk.", "Update all audio IDs");
+
+                if (!updateAllAudioIDs)
+                {
+                    updateOnlyWwiseBankID = PromptForBool("Update the ID of the WwiseBank?\n" +
+                        "In general it's safe and better to do so, but there may be edge cases" +
+                        "where doing so may overwrite parts of the WwiseBank binary that are not its ID.",
+                        "Update WwiseBank ID");
+                }
             }
 
             ExportEntry bioConversation = (ExportEntry)pew.SelectedItem.Entry;
@@ -1623,7 +1633,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            string conversationResult = RenameConversation(pew.Pcc, bioConversation, conversation, newName, updateAudioIDs);
+            string conversationResult = RenameConversation(pew.Pcc, bioConversation, conversation, newName, updateAllAudioIDs, updateOnlyWwiseBankID);
             if (!string.IsNullOrEmpty(conversationResult))
             {
                 ShowError(conversationResult);
@@ -1640,9 +1650,10 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         /// <param name="bioConversation">BioConversation entry to edit.</param>
         /// <param name="conversation">Loaded conversation to edit.</param>
         /// <param name="newName">New name.</param>
-        /// <param name="updateAudioIDs">Whether to update the IDs of Bank, Events, and Streams.</param>
+        /// <param name="updateAllAudioIDs">Whether to update the IDs of Bank, Events, and Streams.</param>
+        /// <param name="updateOnlyWwiseBankID">Whether to only update the ID of the Bank.</param>
         /// <returns>Empty string if no errors, otherwise an error message to display to the user.</returns>
-        public static string RenameConversation(IMEPackage pcc, ExportEntry bioConversation, ConversationExtended conversation, string newName, bool updateAudioIDs)
+        public static string RenameConversation(IMEPackage pcc, ExportEntry bioConversation, ConversationExtended conversation, string newName, bool updateAllAudioIDs, bool updateOnlyWwiseBankID)
         {
             string oldBioConversationName = bioConversation.ObjectName;
             string oldName = GetOldName(pcc, bioConversation, conversation);
@@ -1670,7 +1681,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             }
             else
             {
-                RenameWwiseAudio(pcc, conversation.WwiseBank, bioConversation, oldName, newName, updateAudioIDs, conversation);
+                RenameWwiseAudio(pcc, conversation.WwiseBank, bioConversation, oldName, newName, updateAllAudioIDs, updateOnlyWwiseBankID, conversation);
             }
 
             // Rename bioConversation after the audio, since it needs the old name
@@ -1775,13 +1786,23 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            bool updateAudioIDs = false;
+            bool updateAllAudioIDs = false;
+            bool updateOnlyWwiseBankID = false;
             if (!pew.Pcc.Game.IsGame1())
             {
-                updateAudioIDs = MessageBoxResult.Yes == MessageBox.Show(
-                "Update the IDs of the WwiseBank?\nIn general it's safe and better to do so, but there may be edge cases" +
-                "where doing so may overwrite parts of the WwiseBank binary that are not the IDs.",
-                "Update WwiseBank ID", MessageBoxButton.YesNo);
+                updateAllAudioIDs = PromptForBool("Update all audio IDs?\n" +
+                    "This will give the give the conversation fully unique IDs," +
+                    "hashing the names for the WwiseBank and Stream IDs, and using random generation for the Event IDs," +
+                    "then doing a blind replacement in the binary of the bank. There is a very small chance it may replace something" +
+                    "it shouldn't, so do this at your own risk.", "Update all audio IDs");
+
+                if (!updateAllAudioIDs)
+                {
+                    updateOnlyWwiseBankID = PromptForBool("Update the ID of the WwiseBank?\n" +
+                        "In general it's safe and better to do so, but there may be edge cases" +
+                        "where doing so may overwrite parts of the WwiseBank binary that are not its ID.",
+                        "Update WwiseBank ID");
+                }
             }
 
             string newName = PromptDialog.Prompt(null, "New common name:", "New name");
@@ -1822,7 +1843,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             }
             else
             {
-                RenameWwiseAudio(pew.Pcc, conversation.WwiseBank, bioConversation, oldName, newName, updateAudioIDs, conversation);
+                RenameWwiseAudio(pew.Pcc, conversation.WwiseBank, bioConversation, oldName, newName, updateAllAudioIDs, updateOnlyWwiseBankID, conversation);
             }
 
             MessageBox.Show($"Audio renamed successfully.", "Success", MessageBoxButton.OK);
@@ -1836,10 +1857,11 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         /// <param name="bioConversation">Selected BioConversation.</param>
         /// <param name="oldName">Old name to replace.</param>
         /// <param name="newName">New name for the elements.</param>
-        /// <param name="updateAudioIDs">Whether to update the IDs of Bank, Events, and Streams.</param>
+        /// <param name="updateAllAudioIDs">Whether to update the IDs of the Bank, Events, and Streams.</param>
+        /// <param name="updateOnlyWwiseBankID">Whether to only update the ID of the Bank.</param>
         /// <param name="conversation">Loaded Conversation, to avoid copy/pasting some its code.</param>
         public static void RenameWwiseAudio(IMEPackage pcc, ExportEntry wwiseBankEntry, ExportEntry bioConversation,
-            string oldName, string newName, bool updateAudioIDs, ConversationExtended conversation)
+            string oldName, string newName, bool updateAllAudioIDs, bool updateOnlyWwiseBankID, ConversationExtended conversation)
         {
             string oldWwiseBankName = wwiseBankEntry.ObjectName;
             string newWwiseBankName = oldWwiseBankName.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
@@ -1850,12 +1872,25 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             // RenameWwiseEvents(pcc, wwiseEvents, newName);
             RenameWwiseStreams(pcc, wwiseStreams, oldName, newName);
 
-            if (updateAudioIDs)
+            if (updateAllAudioIDs)
             {
-                // Dictionary<uint, uint> wwiseEventsIDs = UpdateIDs(wwiseEvents);
-                // Dictionary<uint, uint> wwiseStreamsIDs = UpdateIDs(wwiseStreams);
+                Random random = new();
 
-                UpdateAudioIDs(wwiseBankEntry, newWwiseBankName, null, null);
+                Dictionary<uint, uint> idPairs = new();
+                idPairs.AddRange(UpdateIDs_EXPERIMENTAL(wwiseEvents, random));
+                idPairs.AddRange(UpdateIDs_EXPERIMENTAL(wwiseStreams));
+
+                UpdateAudioIDs_EXPERIMENTAL(wwiseBankEntry, newWwiseBankName, idPairs, random);
+            }
+            else
+            {
+                if (updateOnlyWwiseBankID)
+                {
+                    // Dictionary<uint, uint> wwiseEventsIDs = UpdateIDs(wwiseEvents);
+                    // Dictionary<uint, uint> wwiseStreamsIDs = UpdateIDs(wwiseStreams);
+
+                    UpdateAudioIDs_LEGACY(wwiseBankEntry, newWwiseBankName, null, null);
+                }
             }
 
             wwiseBankEntry.ObjectName = newWwiseBankName;
@@ -1887,14 +1922,111 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         /// </summary>
         /// <param name="wwiseBankEntry">The WwiseBank entry to edit.</param>
         /// <param name="newWwiseBankName">The new wwise bank name. Needed for ME3 ReferencedBanks.</param>
+        /// <param name="idPairs">Dictionary<oldID, newID> Found IDs to update.</param>
+        /// <param name="random">Random object to generate IDs.</param>
+        public static void UpdateAudioIDs_EXPERIMENTAL(ExportEntry wwiseBankEntry, string newWwiseBankName,
+            Dictionary<uint, uint> idPairs, Random random)
+        {
+            string oldBankName = wwiseBankEntry.ObjectName;
+
+            (uint oldBankID, uint newBankID) = UpdateID_EXPERIMENTAL(wwiseBankEntry, null, newWwiseBankName);
+
+            WwiseBank wwiseBank = wwiseBankEntry.GetBinaryData<WwiseBank>();
+            // Update the bank id
+            wwiseBank.ID = newBankID;
+
+            idPairs.Add(oldBankID, newBankID);
+
+            // Update referenced banks kvp that reference the old bank name
+            IEnumerable<KeyValuePair<uint, string>> updatedBanks = wwiseBank.ReferencedBanks
+                .Select(referencedBank =>
+                {
+                    if (referencedBank.Value.Equals(oldBankName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new KeyValuePair<uint, string>(newBankID, newWwiseBankName);
+                    }
+                    return referencedBank;
+                });
+            wwiseBank.ReferencedBanks = new(updatedBanks);
+
+            // Gather all the IDs we don't know about yet
+            foreach (WwiseBank.HIRCObject hirc in wwiseBank.HIRCObjects.Values)
+            {
+                if (hirc.ID != 0 && !idPairs.ContainsKey(hirc.ID))
+                {
+                    idPairs.Add(hirc.ID, GenerateRandomID(random));
+                }
+            }
+
+            // Update references to old wwiseEvents' hashes, which are the ID of Event HIRCs.
+            // Update references to old wwiseStreams' hashes, which are in the unknown bytes of Sound HIRCs.
+            // Update references to old bank hash, which I'm certain is at the end of Event Action HIRCs,
+            // but we check in all of them just in case.
+            // byte[] bankIDArr = BitConverter.GetBytes(oldBankID);
+            // byte[] newBankIDArr = BitConverter.GetBytes(newBankID);
+
+            //foreach (WwiseBank.HIRCObject hirc in wwiseBank.HIRCObjects.Values)
+            //{
+            //if (hirc.Type == HIRCType.Event) // References a WwiseEvent
+            //{
+            //    if (wwiseEventIDs.TryGetValue(hirc.ID, out uint newEventID))
+            //    {
+            //        hirc.ID = newEventID;
+            //    }
+            //}
+            //else if (hirc.Type == HIRCType.SoundSXFSoundVoice) // References a WwiseStream
+            //{
+            //    // 4 bytes ID is located at the start after 14 bytes
+            //    Span<byte> streamIDSpan = hirc.unparsed.AsSpan(5..9);
+            //    uint streamIDUInt = BitConverter.ToUInt32(streamIDSpan);
+
+            //    if (wwiseStreamIDs.TryGetValue(streamIDUInt, out uint newStreamIDUInt))
+            //    {
+            //        byte[] newStreamIDArr = BitConverter.GetBytes(newStreamIDUInt);
+            //        newStreamIDArr.CopyTo(streamIDSpan);
+            //    }
+            //}
+
+            // Check for bank ID in all HIRCs, even though I'm almost certain it only appears
+            // in Event Actions
+            //    if (hirc.unparsed != null && hirc.unparsed.Length >= 4) // Only replace if not null and at least width of hash
+            //    {
+            //        Span<byte> bankIDSpan = hirc.unparsed.AsSpan(^4..);
+            //        if (bankIDSpan.SequenceEqual(bankIDArr))
+            //        {
+            //            newBankIDArr.CopyTo(bankIDSpan);
+            //        }
+            //    }
+            //}
+
+            string bankBinaryAsString = Convert.ToHexString(wwiseBankEntry.GetBinaryData());
+
+            // Blindly replace all the IDs found in the WwiseBank
+            foreach (KeyValuePair<uint, uint> id in idPairs)
+            {
+                bankBinaryAsString = bankBinaryAsString.Replace(
+                    BigToLittleEndian(string.Format("{0:X2}", id.Key).PadLeft(8, '0')),
+                    BigToLittleEndian(string.Format("{0:X2}", id.Value).PadLeft(8, '0')),
+                    StringComparison.OrdinalIgnoreCase);
+            }
+
+            wwiseBankEntry.WriteBinary(Convert.FromHexString(bankBinaryAsString));
+
+        }
+
+        /// <summary>
+        /// Update a WwiseBank's ID by hashing a new name and changing it in the binary data where appropriate.
+        /// </summary>
+        /// <param name="wwiseBankEntry">The WwiseBank entry to edit.</param>
+        /// <param name="newWwiseBankName">The new wwise bank name. Needed for ME3 ReferencedBanks.</param>
         /// <param name="wwiseEventIDs">Dictionary<oldID, newID> The event IDs to update</param>
         /// <param name="wwiseStreamIDs">Dictionary<oldID, newID> The stream IDs to update</param>
-        public static void UpdateAudioIDs(ExportEntry wwiseBankEntry, string newWwiseBankName,
+        public static void UpdateAudioIDs_LEGACY(ExportEntry wwiseBankEntry, string newWwiseBankName,
             Dictionary<uint, uint> wwiseEventIDs, Dictionary<uint, uint> wwiseStreamIDs)
         {
             string oldBankName = wwiseBankEntry.ObjectName;
 
-            (uint oldBankID, uint newBankID) = UpdateID(wwiseBankEntry, newWwiseBankName);
+            (uint oldBankID, uint newBankID) = UpdateID_LEGACY(wwiseBankEntry, newWwiseBankName);
 
             WwiseBank wwiseBank = wwiseBankEntry.GetBinaryData<WwiseBank>();
             // Update the bank id
@@ -1932,7 +2064,6 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 //    // 4 bytes ID is located at the start after 14 bytes
                 //    Span<byte> streamIDSpan = hirc.unparsed.AsSpan(5..9);
                 //    uint streamIDUInt = BitConverter.ToUInt32(streamIDSpan);
-
                 //    if (wwiseStreamIDs.TryGetValue(streamIDUInt, out uint newStreamIDUInt))
                 //    {
                 //        byte[] newStreamIDArr = BitConverter.GetBytes(newStreamIDUInt);
@@ -2019,16 +2150,62 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         /// Update the IDs of a list of ExportEntries with hashes of their names.
         /// </summary>
         /// <param name="entries">WwiseStreams to update.</param>
+        /// <param name="random">If not null, the random object to generate ids, instead of the name.</param>
         /// <returns>KVP of old and new IDs. Used to update references.</returns>
-        private static Dictionary<uint, uint> UpdateIDs(List<ExportEntry> entries)
+        private static Dictionary<uint, uint> UpdateIDs_EXPERIMENTAL(List<ExportEntry> entries, Random random = null)
+        {
+            Dictionary<uint, uint> oldAndNewIDs = new();
+
+            foreach (ExportEntry entry in entries)
+            {
+                (uint oldID, uint newID) = UpdateID_EXPERIMENTAL(entry, random);
+
+                if (newID == 0) { continue; }
+
+                oldAndNewIDs.Add(oldID, newID);
+            }
+
+            return oldAndNewIDs;
+        }
+
+        /// <summary>
+        /// Update the ID of an ExportEntry with a hash of the provided name.
+        /// </summary>
+        /// <param name="entry">Entry to update.</param>
+        /// <param name="random">Random object used for generating random IDs, otherwise use the object's name.</param>
+        /// <param name="name">Name to use for the name generation, if not random. If not random and empty, use the object's name.</param>
+        /// <returns>KVP of old and new ID. Used to update references.</returns>
+        private static (uint, uint) UpdateID_EXPERIMENTAL(ExportEntry entry, Random random = null, string name = "")
+        {
+            IntProperty IDProp = entry.GetProperty<IntProperty>("Id");
+            if (IDProp == null) { return (0, 0); }
+
+            // Get/Generate IDs and little endian hashes
+            uint oldID = unchecked((uint)IDProp.Value);
+            uint newID = random != null
+                ? GenerateRandomID(random)
+                : CalculateFNV132Hash(string.IsNullOrEmpty(name) ? entry.ObjectName.Name : name);
+
+            // Update the ID property
+            IDProp.Value = unchecked((int)newID);
+            entry.WriteProperty(IDProp);
+
+            return (oldID, newID);
+        }
+
+        /// <summary>
+        /// Update the IDs of a list of ExportEntries with hashes of their names.
+        /// </summary>
+        /// <param name="entries">WwiseStreams to update.</param>
+        /// <returns>KVP of old and new IDs. Used to update references.</returns>
+        private static Dictionary<uint, uint> UpdateIDs_LEGACY(List<ExportEntry> entries)
         {
             Dictionary<uint, uint> oldAndNewIDs = new();
             foreach (ExportEntry entry in entries)
             {
-                (uint oldID, uint newID) = UpdateID(entry);
+                (uint oldID, uint newID) = UpdateID_LEGACY(entry);
 
                 if (newID == 0) { continue; }
-
                 oldAndNewIDs.Add(oldID, newID);
             }
 
@@ -2040,11 +2217,10 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         /// </summary>
         /// <param name="entry">Entry to update.</param>
         /// <returns>KVP of old and new ID. Used to update references.</returns>
-        private static (uint, uint) UpdateID(ExportEntry entry)
+        private static (uint, uint) UpdateID_LEGACY(ExportEntry entry)
         {
             string name = entry.ObjectName.Name;
-
-            return UpdateID(entry, name);
+            return UpdateID_LEGACY(entry, name);
         }
 
         /// <summary>
@@ -2053,9 +2229,10 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
         /// <param name="entry">Entry to update.</param>
         /// <param name="name">Name to use for hash.</param>
         /// <returns>KVP of old and new ID. Used to update references.</returns>
-        private static (uint, uint) UpdateID(ExportEntry entry, string name)
+        private static (uint, uint) UpdateID_LEGACY(ExportEntry entry, string name)
         {
             IntProperty IDProp = entry.GetProperty<IntProperty>("Id");
+
             if (IDProp == null) { return (0, 0); }
 
             // Get/Generate IDs and little endian hashes
@@ -2294,7 +2471,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
 
             return "";
         }
-       
+
         /// <summary>
         /// Wrapper for UpdateAmbPerfClass so it can used as a full experiment on its own.
         /// </summary>
@@ -2309,7 +2486,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            int propResourceID = promptForInt("PropResource export number:", "Not a valid export number. It must be positive integer", -1, "PropResouce export number");
+            int propResourceID = PromptForInt("PropResource export number:", "Not a valid export number. It must be positive integer", -1, "PropResouce export number");
             if (propResourceID == -1) { return; }
             if (!pew.Pcc.TryGetUExport(propResourceID, out ExportEntry propResource))
             {
@@ -2322,7 +2499,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            UpdateAmbPerfClass(pew.Pcc, (ExportEntry) pew.SelectedItem.Entry, propResource);
+            UpdateAmbPerfClass(pew.Pcc, (ExportEntry)pew.SelectedItem.Entry, propResource);
 
             MessageBox.Show("Properties of SFXAmbPerfGameData updated successfully.", "Success", MessageBoxButton.OK);
         }
@@ -2341,7 +2518,7 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
                 return;
             }
 
-            int propResourceID = promptForInt("PropResource export number:", "Not a valid export number. It must be positive integer", -1, "PropResouce export number");
+            int propResourceID = PromptForInt("PropResource export number:", "Not a valid export number. It must be positive integer", -1, "PropResouce export number");
             if (propResourceID == -1) { return; }
             if (!pew.Pcc.TryGetUExport(propResourceID, out ExportEntry propResource))
             {
@@ -2397,130 +2574,817 @@ namespace LegendaryExplorer.Tools.PackageEditor.Experiments
             ambPerfGameData.WriteProperties(props);
         }
 
+        /// <summary>
+        /// Replaces the colors in the DirectionalSamples of the 1D Lightmap of a StaticMeshComponent
+        /// </summary>
+        /// <param name="pew">Current PE window.</param>
+        public static void Replace1DLightMapColors(PackageEditorWindow pew)
+        {
+            if (pew.Pcc == null || pew.SelectedItem?.Entry == null) { return; }
+
+            IMEPackage pcc = pew.Pcc;
+            if (pew.SelectedItem.Entry.ClassName is not "StaticMeshComponent")
+            {
+                ShowError("Selected export is not an StaticMeshComponent");
+                return;
+            }
+
+            ExportEntry component = pew.SelectedItem.Entry as ExportEntry;
+
+            if (ObjectBinary.From(component) is not StaticMeshComponent sc)
+            {
+                ShowError("Wrong binary data.");
+                return;
+            }
+
+            Dictionary<int, string> colorMap = GetColorMap(sc.LODData);
+
+            string colors = string.Join("; ", colorMap.Select(pair => $"{pair.Key}: {pair.Value}"));
+
+            MessageBoxResult response = MessageBox.Show($"Found {colorMap.Count} colors.\n\nDo you want to copy them to the clipboard?\nThey'll appear in the form of <color id>: <hexadecimal>.", "", MessageBoxButton.YesNo);
+            if (response == MessageBoxResult.Yes) { Clipboard.SetText(colors); }
+
+            string newColorsString = PromptDialog.Prompt(null,
+                "Paste a ; separated list of color IDs and the new hexadecimal color values to patch, in the following form:\n" +
+                "<color id 1>: <hexadecimal 1>; <color id 2>: <hexadecimal 2>; ...\n\n");
+
+            if (string.IsNullOrEmpty(newColorsString))
+            {
+                ShowError("Invalid colors list.");
+                return;
+            }
+
+            Dictionary<int, (int, int, int)> newColorMap = new();
+
+            foreach (string s in newColorsString.Split(";"))
+            {
+                if (!s.Contains(':'))
+                {
+                    ShowError("Wrong formatting for color ids and hex.");
+                    return;
+                }
+
+                // Validate values
+                string[] temp = s.Trim().Split(":");
+                if (!int.TryParse(temp[0], out int id))
+                {
+                    ShowError($"The {s}'s id is not an int.");
+                    return;
+                }
+
+                newColorMap.Add(id, HexToRGB(temp[1].Trim()));
+            }
+
+            ApplyColorMap(newColorMap, sc.LODData);
+
+            component.WriteBinary(sc);
+
+            MessageBox.Show("The colors were sucessfully replaced", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Replaces the colors in the DirectionalSamples of the 1D Lightmap of the StaticMeshComponent of the given export IDs.
+        /// /// </summary>
+        /// <param name="pew">Current PE window</param>
+        public static void Replace1DLightMapColorsOfExports(PackageEditorWindow pew)
+        {
+            if (pew.Pcc == null) { return; }
+
+            IMEPackage pcc = pew.Pcc;
+
+            // Get IDs of exports to edit
+            string exportsString = PromptDialog.Prompt(null, "Write a comma separated list of export IDs of the StaticMeshComponents to edit");
+            if (string.IsNullOrEmpty(exportsString))
+            {
+                ShowError("Invalid list");
+                return;
+            }
+
+            List<ExportEntry> components = new();
+
+            foreach (string exportStr in exportsString.Split(','))
+            {
+                if (!int.TryParse(exportStr, out int id))
+                {
+                    ShowError($"{exportStr} is not a valid ID");
+                    return;
+                }
+
+                if (!pcc.TryGetUExport(id, out ExportEntry export))
+                {
+                    ShowError($"{exportStr} is not a valid export");
+                    return;
+                }
+
+                if (export.ClassName != "StaticMeshComponent")
+                {
+                    ShowError($"{exportStr} is not a StaticMeshComponent");
+                    return;
+                }
+
+                components.Add(export);
+            }
+
+            string colors = "";
+            int mapCount = 0;
+
+            foreach (ExportEntry component in components)
+            {
+                if (ObjectBinary.From(component) is not StaticMeshComponent sc) { continue; }
+
+                Dictionary<int, string> colorMap = GetColorMap(sc.LODData);
+                if (colorMap.Count == 0) { continue; } // Takes care of components with no 1D LightMaps
+
+                colors += $"IDX{component.UIndex} - {string.Join("; ", colorMap.Select(pair => $"{pair.Key}: {pair.Value}"))}@\n";
+
+                mapCount++;
+            }
+
+            if (string.IsNullOrEmpty(colors))
+            {
+                ShowError("No 1D LightMaps were found in the file.");
+                return;
+            }
+
+            MessageBoxResult response = MessageBox.Show($"Found {mapCount} 1D LightMaps.\n\nDo you want to copy the colors to the clipboard?\n\nThey'll appear in the following form:\nIDX<lightMap index> - <color id>: <hexadecimal>; ...", "", MessageBoxButton.YesNo);
+            if (response == MessageBoxResult.Yes) { Clipboard.SetText(colors); }
+
+            string newColorsString = PromptDialog.Prompt(null,
+                "Paste a list of light map IDs and a ; separated list of their color IDs and the new hexadecimal color values to patch, in the following form:\n" +
+                "IDX<map export index 1> - <color id 1>: <hexadecimal 1>; <color id 2>: <hexadecimal 2>; ...\n" +
+                "IDX<map export index n> - <color id n>: <hexadecimal n>; <color id n>: <hexadecimal n>; ...\n\n");
+
+            if (string.IsNullOrEmpty(newColorsString))
+            {
+                ShowError("Invalid colors list.");
+                return;
+            }
+
+            foreach (string line in newColorsString.Split('@'))
+            {
+                if (string.IsNullOrEmpty(line)) { continue; }
+
+                string[] parts = line.Split("-");
+                if (!int.TryParse(parts[0].Trim()[3..], out int idx)) { continue; }
+                string newColors = parts[1].Trim();
+
+                if (!pcc.TryGetUExport(idx, out ExportEntry component)) { continue; }
+                if (ObjectBinary.From(component) is not StaticMeshComponent sc) { continue; }
+
+                Dictionary<int, (int, int, int)> newColorMap = new();
+
+                foreach (string s in newColors.Split(";"))
+                {
+                    if (!s.Contains(':')) { continue; }
+
+                    // Validate values
+                    string[] temp = s.Trim().Split(":");
+                    if (!int.TryParse(temp[0], out int id)) { continue; }
+
+                    newColorMap.Add(id, HexToRGB(temp[1].Trim()));
+                }
+
+                ApplyColorMap(newColorMap, sc.LODData);
+
+                component.WriteBinary(sc);
+            }
+
+            MessageBox.Show("The colors were sucessfully replaced", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Replaces the colors in the DirectionalSamples of the 1D Lightmap of all StaticMeshComponent
+        /// </summary>
+        /// <param name="pew">Current PE window</param>
+        public static void BatchReplace1DLightMapColors(PackageEditorWindow pew)
+        {
+            if (pew.Pcc == null) { return; }
+
+            IMEPackage pcc = pew.Pcc;
+
+            List<ExportEntry> components = pcc.Exports.Where(exp => exp.ClassName == "StaticMeshComponent").ToList();
+
+            if (components.Count == 0)
+            {
+                ShowError("No StaticMeshComponents found in the file.");
+                return;
+            }
+
+            string colors = "";
+            int mapCount = 0;
+
+            foreach (ExportEntry component in components)
+            {
+                if (ObjectBinary.From(component) is not StaticMeshComponent sc) { continue; }
+
+                Dictionary<int, string> colorMap = GetColorMap(sc.LODData);
+                if (colorMap.Count == 0) { continue; } // Takes care of components with no 1D LightMaps
+
+                colors += $"IDX{component.UIndex} - {string.Join("; ", colorMap.Select(pair => $"{pair.Key}: {pair.Value}"))}@\n";
+
+                mapCount++;
+            }
+
+            if (string.IsNullOrEmpty(colors))
+            {
+                ShowError("No 1D LightMaps were found in the file.");
+                return;
+            }
+
+            MessageBoxResult response = MessageBox.Show($"Found {mapCount} 1D LightMaps.\n\nDo you want to copy the colors to the clipboard?\n\nThey'll appear in the following form:\nIDX<lightMap index> - <color id>: <hexadecimal>; ...", "", MessageBoxButton.YesNo);
+            if (response == MessageBoxResult.Yes) { Clipboard.SetText(colors); }
+
+            string newColorsString = PromptDialog.Prompt(null,
+                "Paste a list of light map IDs and a ; separated list of their color IDs and the new hexadecimal color values to patch, in the following form:\n" +
+                "IDX<map export index 1> - <color id 1>: <hexadecimal 1>; <color id 2>: <hexadecimal 2>; ...\n" +
+                "IDX<map export index n> - <color id n>: <hexadecimal n>; <color id n>: <hexadecimal n>; ...\n\n");
+
+            if (string.IsNullOrEmpty(newColorsString))
+            {
+                ShowError("Invalid colors list.");
+                return;
+            }
+
+            foreach (string line in newColorsString.Split('@'))
+            {
+                if (string.IsNullOrEmpty(line)) { continue; }
+
+                string[] parts = line.Split("-");
+                if (!int.TryParse(parts[0].Trim()[3..], out int idx)) { continue; }
+                string newColors = parts[1].Trim();
+
+                if (!pcc.TryGetUExport(idx, out ExportEntry component)) { continue; }
+                if (ObjectBinary.From(component) is not StaticMeshComponent sc) { continue; }
+
+                Dictionary<int, (int, int, int)> newColorMap = new();
+
+                foreach (string s in newColors.Split(";"))
+                {
+                    if (!s.Contains(':')) { continue; }
+
+                    // Validate values
+                    string[] temp = s.Trim().Split(":");
+                    if (!int.TryParse(temp[0], out int id)) { continue; }
+
+                    newColorMap.Add(id, HexToRGB(temp[1].Trim()));
+                }
+
+                ApplyColorMap(newColorMap, sc.LODData);
+
+                component.WriteBinary(sc);
+            }
+
+            MessageBox.Show("The colors were sucessfully replaced", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Adds the ForcedExport flag to all descendant exports of the selected export, including itself
+        /// </summary>
+        /// <param name="pew">Current PE window</param>
+        public static void MakeExportsForced(PackageEditorWindow pew)
+        {
+            if (pew.Pcc == null) { return; }
+
+            IMEPackage pcc = pew.Pcc;
+
+            if (pew.SelectedItem == null) { return; }
+
+            if (pew.SelectedItem.Entry is not ExportEntry)
+            {
+                ShowError("The selected entry is not an export");
+                return;
+            }
+
+            List<IEntry> entries = pew.SelectedItem.Entry.GetAllDescendants();
+            entries.Add(pew.SelectedItem.Entry);
+
+            foreach (IEntry entry in entries)
+            {
+                if (entry is not ExportEntry export) { continue; }
+
+                if (export.ClassName == "ObjectReferencer") { continue; }
+
+                if ((export.ExportFlags & UnrealFlags.EExportFlags.ForcedExport) == 0)
+                {
+                    export.ExportFlags |= UnrealFlags.EExportFlags.ForcedExport;
+                }
+            }
+
+            MessageBox.Show("Set the ForcedExport flag in all exports", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Gathers all the colors in the DirectionalSamples of a the 1D LightMap in the LODData.
+        /// </summary>
+        /// <param name="LODData">LODs to get the samples from.</param>
+        /// <returns>A dictionary of packged RGBA integer keys and its corresponding hex color.</returns>
+        private static Dictionary<int, string> GetColorMap(StaticMeshComponentLODInfo[] LODData)
+        {
+            Dictionary<int, string> colorMap = new();
+
+            foreach (StaticMeshComponentLODInfo lod in LODData)
+            {
+                if (lod.LightMap.LightMapType == ELightMapType.LMT_1D && lod.LightMap is LightMap_1D lm1)
+                {
+                    foreach (QuantizedDirectionalLightSample qds in lm1.DirectionalSamples)
+                    {
+                        List<string> sample = new();
+                        colorMap[qds.Coefficient1.ToRgba()] = RGBToHex(qds.Coefficient1);
+                        colorMap[qds.Coefficient2.ToRgba()] = RGBToHex(qds.Coefficient2);
+                        colorMap[qds.Coefficient3.ToRgba()] = RGBToHex(qds.Coefficient3);
+                    }
+                }
+            }
+
+            return colorMap;
+        }
+
+        /// <summary>
+        /// Applies a color map of packed rgba int keys and (r, g, b) colors to the directional samples in the 1D maps.
+        /// </summary>
+        /// <param name="newColorMap">New colors to apply.</param>
+        /// <param name="LODData">LOD to apply the colors to.</param>
+        private static void ApplyColorMap(Dictionary<int, (int, int, int)> newColorMap, StaticMeshComponentLODInfo[] LODData)
+        {
+            foreach (StaticMeshComponentLODInfo lod in LODData)
+            {
+                if (lod.LightMap.LightMapType == ELightMapType.LMT_1D && lod.LightMap is LightMap_1D lm1)
+                {
+                    foreach (QuantizedDirectionalLightSample qds in lm1.DirectionalSamples)
+                    {
+                        List<string> sample = new();
+                        qds.Coefficient1 = EditColor(qds.Coefficient1, newColorMap);
+                        qds.Coefficient2 = EditColor(qds.Coefficient2, newColorMap);
+                        qds.Coefficient3 = EditColor(qds.Coefficient3, newColorMap);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts the RGB values in a Color to hexadecimal.
+        /// </summary>
+        /// <param name="coefficient">Color to edit.</param>
+        /// <returns>The hexadecimal string.</returns>
+        private static string RGBToHex(Color coefficient)
+        {
+            byte red = Convert.ToByte(coefficient.R);
+            byte green = Convert.ToByte(coefficient.G);
+            byte blue = Convert.ToByte(coefficient.B);
+
+            return $"#{red:X2}{green:X2}{blue:X2}";
+        }
+
+        /// <summary>
+        /// Converts a hexadecimal color into R,G,B values.
+        /// </summary>
+        /// <param name="hexColor">Hexadecimal color.</param>
+        /// <returns>R,G,B tuple.</returns>
+        private static (int, int, int) HexToRGB(string hexColor)
+        {
+            if (hexColor.Length == 7 && hexColor[0] == '#')
+            {
+                byte red = Convert.ToByte(hexColor.Substring(1, 2), 16);
+                byte green = Convert.ToByte(hexColor.Substring(3, 2), 16);
+                byte blue = Convert.ToByte(hexColor.Substring(5, 2), 16);
+
+
+                return (red, green, blue);
+            }
+            else
+            {
+                return (0, 0, 0);
+            }
+        }
+
+        /// <summary>
+        /// Edit the R,G,B values of a Color with the ones provided in the colorMap.
+        /// </summary>
+        /// <param name="color">Color to edit.</param>
+        /// <param name="colorMap">Map containing the new color.</param>
+        /// <returns>Edited color.</returns>
+        private static Color EditColor(Color color, Dictionary<int, (int, int, int)> colorMap)
+        {
+            if (colorMap.TryGetValue(color.ToRgba(), out (int, int, int) rgb))
+            {
+                color.R = (byte)rgb.Item1;
+                color.G = (byte)rgb.Item2;
+                color.B = (byte)rgb.Item3;
+            }
+            return color;
+        }
+
+        /// <summary>
+        /// Collect all StaticMeshComponents, referenced by StatichMeshActors, and add them into a new StaticMeshCollectionActor
+        /// </summary>
+        /// <param name="pew">Current PE window</param>
+        public static void CollectSMCsintoSMCA(PackageEditorWindow pew)
+        {
+            if (pew.Pcc == null) { return; }
+
+            IMEPackage pcc = pew.Pcc;
+
+            bool trashActors = MessageBoxResult.Yes == MessageBox.Show(
+                "Trash actors that referenced the StaticMeshComponents?\n" +
+                "References to the actors in the PersistentLevel will be removed, but other references may remain.",
+                "Trash actors", MessageBoxButton.YesNo);
+
+            List<ExportEntry> actors = pcc.Exports.Where(exp => exp.ClassName == "StaticMeshActor").ToList();
+
+            if (actors.Count == 0)
+            {
+                ShowError("No StaticMeshActors found in the file.");
+                return;
+            }
+
+            Dictionary<ExportEntry, (Vector3, Rotator, Vector3)> SMCsAndPos = [];
+            List<IEntry> actorsToTrash = [];
+
+            // Collect components referenced by actors and the location, rotation, and draw scale values
+            foreach (ExportEntry actor in actors)
+            {
+                PropertyCollection actorProps = actor.GetProperties();
+
+                ObjectProperty smcRef = actorProps.GetProp<ObjectProperty>("StaticMeshComponent");
+
+                if (smcRef == null || !pcc.TryGetUExport(smcRef.Value, out ExportEntry smc))
+                {
+                    continue;
+                }
+
+                Vector3 loc = GetTransformationData(actor, "Location");
+                Vector3 rot = GetTransformationData(actor, "Rotation");
+                Vector3 draw = GetTransformationData(actor, "DrawScale3D");
+
+                SMCsAndPos.Add(smc, (loc, new Rotator((int)rot.X, (int)rot.Y, (int)rot.Z), draw));
+
+                actor.RemoveProperty("StaticMeshComponent");
+                actorsToTrash.Add(actor);
+            }
+
+            // Prepare the props for the new StaticMeshCollectionActor
+            PropertyCollection collectionProps = [
+                new ArrayProperty<ObjectProperty>(
+                    SMCsAndPos.Select(kvp => new ObjectProperty(kvp.Key)), "StaticMeshComponents"),
+                new NameProperty("StaticMeshCollectionActor", "Tag")
+            ];
+
+            ExportEntry persistentLevel = pcc.FindExport("TheWorld.PersistentLevel");
+
+            // Create the actor
+            ExportEntry smca = CreateExport(pcc, pcc.GetNextIndexedName("StaticMeshCollectionActor"), "StaticMeshCollectionActor",
+                persistentLevel, collectionProps);
+
+            // Prepare the binary for the new StaticMeshCollectionActor
+            StaticMeshCollectionActor collectionBinary = new()
+            {
+                Export = smca,
+                Components = SMCsAndPos.Select(kvp => kvp.Key.UIndex).ToList(),
+                LocalToWorldTransforms = SMCsAndPos.Select(kvp =>
+                {
+                    (Vector3 loc, Rotator rot, Vector3 draw) = kvp.Value;
+                    return ActorUtils.ComposeLocalToWorld(loc, rot, draw);
+                }).ToList()
+            };
+            smca.WriteBinary(collectionBinary);
+
+            // Add the new collection actor reference to the PersistentLevel
+            Level plBinary = ObjectBinary.From<Level>(persistentLevel);
+            plBinary.Actors.Add(smca.UIndex);
+            if (trashActors)
+            {
+                foreach (IEntry actor in actorsToTrash)
+                {
+                    plBinary.Actors.TryRemove((uidx => uidx == actor.UIndex), out _);
+                }
+            }
+            persistentLevel.WriteBinary(plBinary);
+
+            // Relink the components to the new collection actor
+            foreach (KeyValuePair<ExportEntry, (Vector3, Rotator, Vector3)> kvp in SMCsAndPos)
+            {
+                kvp.Key.idxLink = smca.UIndex;
+            }
+
+            if (trashActors)
+            {
+                EntryPruner.TrashEntries(pcc, actorsToTrash);
+            }
+
+            MessageBox.Show($"Created {smca.InstancedFullPath} with {SMCsAndPos.Count} StaticMeshComponents", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Get the transformation data that matches the given propName.
+        /// </summary>
+        /// <param name="actor">Actor to find the data on.</param>
+        /// <param name="propName">Name of the prop to get the data of.</param>
+        /// <returns>Vector3 containing the three transformation values of the prop.</returns>
+        private static Vector3 GetTransformationData(ExportEntry actor, string propName)
+        {
+            StructProperty prop = actor.GetProperty<StructProperty>(propName);
+
+            // Try to get the data from the archetype.
+            // Useful in case of prefabs.
+            if (prop == null)
+            {
+                IEntry archetype = actor.Archetype;
+
+                if (archetype == null) { return new Vector3(); } // Exit if no prop in actor or archeytpe
+
+                if (archetype is ImportEntry entry)
+                {
+                    archetype = EntryImporter.ResolveImport(entry);
+                }
+
+                prop = ((ExportEntry)archetype).GetProperty<StructProperty>(propName);
+            }
+
+            switch (propName)
+            {
+                case "Location":
+                case "DrawScale3D":
+                    return prop != null
+                        ? new Vector3(prop.GetProp<FloatProperty>("X"), prop.GetProp<FloatProperty>("Y"), prop.GetProp<FloatProperty>("Z"))
+                        : new Vector3(0, 0, 0);
+                case "Rotation":
+                    return prop != null
+                        ? new Vector3(prop.GetProp<FloatProperty>("Pitch"), prop.GetProp<FloatProperty>("Yaw"), prop.GetProp<FloatProperty>("Roll"))
+                        : new Vector3(0, 0, 0);
+                default:
+                    return new Vector3(0, 0, 0);
+            }
+        }
+
+        /// <summary>
+        /// Creates instances of all the prefab archetypes of a Prefab into the file's persistent level.
+        /// </summary>
+        /// <param name="pew">Current PE window.</param>
+        public static void AddPrefabToLevel(PackageEditorWindow pew)
+        {
+            if (pew.Pcc == null || pew.SelectedItem?.Entry == null) { return; }
+
+            if (pew.SelectedItem.Entry.ClassName is not "Prefab" || !(pew.SelectedItem.Entry is ExportEntry prefab))
+            {
+                ShowError("Selected export is not Prefab");
+                return;
+            }
+
+            ArrayProperty<ObjectProperty> prefabArchetypes = prefab.GetProperty<ArrayProperty<ObjectProperty>>("PrefabArchetypes");
+            if (prefabArchetypes == null)
+            {
+                ShowError("The Prefab contains no PrefabArchetypes property");
+                return;
+            }
+
+            if (!(pew.Pcc.FindExport("TheWorld.PersistentLevel") is ExportEntry { ClassName: "Level" } levelExport))
+            {
+                ShowError("No PersistentLevel found in the file.");
+                return;
+            }
+
+            Level level = ObjectBinary.From<Level>(levelExport);
+
+            foreach (ObjectProperty archRef in prefabArchetypes)
+            {
+                // Either cast the archetype or resolve it, so we clone an ExportEntry
+                IEntry entry = pew.Pcc.GetEntry(archRef.Value);
+                ExportEntry archetype = ResolveEntryToExport(entry);
+
+                ExportEntry newExport;
+
+                // General creation
+                switch (archetype.ClassName)
+                {
+                    case "BioDoor":
+                        continue; // Skip BioDoors, as adding the causes crashes
+                    case "PointLight":
+                    case "SpotLight":
+                    case "StaticMeshActor":
+                        newExport = CreateExport(pew.Pcc, archetype.ObjectName, archetype.ClassName, levelExport, archetype.GetProperties(),
+                            null, null, null, archetype); // Create the export
+                        AddStack(newExport); // Add preProps binary
+                        break;
+                    default:
+                        newExport = ClonePrefabArchetype(entry, archetype, levelExport);
+                        break;
+                }
+
+                // Specific operations on the different classes. We could have a single switch case, but given that they need the export to already
+                // be created, and the specificities, it's cleaner to have two separate steps.
+                switch (archetype.ClassName)
+                {
+                    case "PointLight":
+                    case "SpotLight":
+                        AddLightingChannelsToComponent(pew.Pcc, archetype);
+                        break;
+                    case "StaticMeshActor":
+                        AddComponentsToActor(pew.Pcc, archetype, newExport); // Copy relevant components
+                        break;
+                    case "BioSunActor":
+                        FixPackageOfSunSprites(pew.Pcc, archetype.GetProperties());
+                        break;
+                    default:
+                        break;
+                }
+
+                level.Actors.Add(newExport.UIndex);
+            }
+
+            levelExport.WriteBinary(level);
+
+            MessageBox.Show("Added instances of all the archetypes in the Prefab to the PersistentLevel.", "Success", MessageBoxButton.OK);
+        }
+
+        /// <summary>
+        /// Add the StaticMeshComponent and CollisionComponent of the source into the target, adding their proper binary in the process.
+        /// </summary>
+        /// <param name="pcc">Package to operate on.</param>
+        /// <param name="source">Source export to clone the components from.</param>
+        /// <param name="target">Target export to clone the components into.</param>
+        private static void AddComponentsToActor(IMEPackage pcc, ExportEntry source, ExportEntry target)
+        {
+            PropertyCollection sourceProps = source.GetProperties();
+            PropertyCollection targetProps = target.GetProperties();
+
+            switch (target.ClassName)
+            {
+                case "StaticMeshActor":
+                    CopyComponentToProps(pcc, "StaticMeshComponent", target, sourceProps, targetProps);
+                    CopyComponentToProps(pcc, "CollisionComponent", target, sourceProps, targetProps);
+                    break;
+                default:
+                    break;
+            }
+
+            target.WriteProperties(targetProps);
+        }
+
+        /// <summary>
+        /// Copy a source component into a new object, and add the new property to the target collection.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="componentName">Name of the component to copy.</param>
+        /// <param name="parent">Parent export to link the component to.</param>
+        /// <param name="sourceProps">Props possibly containing the component to copy.</param>
+        /// <param name="targetProps">Props to copy the component into.</param>
+        /// <returns></returns>
+        private static void CopyComponentToProps(IMEPackage pcc, string componentName, ExportEntry parent, PropertyCollection sourceProps, PropertyCollection targetProps)
+        {
+            ObjectProperty componentRef = sourceProps.GetProp<ObjectProperty>(componentName);
+
+            if (componentRef != null)
+            {
+                ExportEntry sourceComponent = ResolveEntryToExport(pcc.GetEntry(componentRef.Value));
+                PropertyCollection sourceComponentProps = sourceComponent.GetProperties();
+                ExportEntry newComponent = CreateExport(pcc, sourceComponent.ObjectName, sourceComponent.ClassName, parent, sourceComponentProps,
+                    sourceComponent.GetBinaryData(), new byte[8]);
+
+                targetProps.AddOrReplaceProp(new ObjectProperty(newComponent.UIndex, componentName));
+            }
+        }
+
+        /// <summary>
+        /// Clone an archetype from a prefab into the PersistentLevel.
+        /// </summary>
+        /// <param name="archetypeEntry">Archetype entry, may be an import or an export.</param>
+        /// <param name="archetype">Resolved export of the archetype, in case it was an import.</param>
+        /// <param name="persistentLevel">PersistentLevel to add the clone to.</param>
+        /// <returns></returns>
+        private static ExportEntry ClonePrefabArchetype(IEntry archetypeEntry, ExportEntry archetype, ExportEntry persistentLevel)
+        {
+            ExportEntry newExport = EntryCloner.CloneEntry(archetype);
+            newExport.Archetype = archetypeEntry;
+            newExport.idxLink = persistentLevel.UIndex;
+
+            // Set the proper flags
+            newExport.ObjectFlags &= ~UnrealFlags.EObjectFlags.ArchetypeObject;
+            newExport.ObjectFlags &= ~UnrealFlags.EObjectFlags.Public;
+            newExport.ObjectFlags |= UnrealFlags.EObjectFlags.Transactional;
+
+            ObjectBinary binary = ObjectBinary.From(newExport);
+            if (binary == null) { newExport.WriteBinary(ObjectBinary.Create(newExport.ClassName, newExport.FileRef.Game, newExport.GetProperties())); }
+
+            return newExport;
+        }
+
+        /// <summary>
+        /// Add lighting channels to the LightComponents, in case they don't have them, as otherwise they won't appear.
+        /// You'd think that you'd be better copying the component and adding it in the PersistentLevel,
+        /// but that seems to do nothing, they need to be added to the archetype in the Prefab.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="parent">Parent export of the LightComponent.</param>
+        private static void AddLightingChannelsToComponent(IMEPackage pcc, ExportEntry parent)
+        {
+            ObjectProperty componentRef = parent.GetProperties().GetProp<ObjectProperty>("LightComponent");
+
+            if (componentRef != null)
+            {
+                ExportEntry lightComponent = ResolveEntryToExport(pcc.GetEntry(componentRef.Value));
+
+                StructProperty lightingChannels = lightComponent.GetProperty<StructProperty>("LightingChannels")
+                    ?? new StructProperty("LightingChannelContainer", new PropertyCollection(), "LightingChannels");
+
+                lightingChannels.Properties.AddOrReplaceProp(new BoolProperty(true, "Static"));
+                lightingChannels.Properties.AddOrReplaceProp(new BoolProperty(true, "Dynamic"));
+
+                lightComponent.WriteProperty(lightingChannels);
+            }
+        }
+
+        /// <summary>
+        /// Find the SunSprite components that are ImportEntries, if any, then change their package file to SFXGame, if it's BIOC_Base.
+        /// </summary>
+        /// <param name="pcc">Pcc to operate on.</param>
+        /// <param name="props">Props containing the components references.</param>
+        private static void FixPackageOfSunSprites(IMEPackage pcc, PropertyCollection props)
+        {
+            foreach (Property prop in props)
+            {
+                if (prop.PropType != PropertyType.ObjectProperty && !prop.Name.Name.Contains("Sprite")) { continue; }
+                // if (prop.PropType != PropertyType.ObjectProperty || (!prop.Name.Name.Contains("HaloSprite") && !prop.Name.Name.Contains("FlareSprite"))) { continue; }
+
+                IEntry flareEntry = pcc.GetEntry(((ObjectProperty)prop).Value);
+
+                ImportEntry flareImport;
+
+                // Try to find if the component or its archetype are an import,
+                // so we can operate on them
+                if (flareEntry is ExportEntry export)
+                {
+                    IEntry flareArchetype = export.Archetype;
+
+                    if (flareArchetype is ImportEntry import) { flareImport = import; }
+                    else { continue; } // Neither the component nor its archetype were an import, so we skip it
+                }
+                else
+                {
+                    flareImport = (ImportEntry)flareEntry;
+                }
+
+                if (flareImport.PackageFile.CaseInsensitiveEquals("BIOC_Base"))
+                {
+                    flareImport.PackageFile = "SFXGame";
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds a level streaming kismet to either TheWorld or PersistentLevel.
+        /// </summary>
+        /// <param name="pew">Current PE window</param>
+        public static void AddStreamingKismetExperiment(PackageEditorWindow pew)
+        {
+            if (pew.Pcc == null) { return; }
+
+            string filename = PromptForStr("Name of file to set in the streaming kismet:", "Not a valid file name.");
+            if (string.IsNullOrEmpty(filename))
+            {
+                ShowError("Not a valid file name.");
+                return;
+            }
+            bool inPersistentLevel = PromptForBool("Yes adds the object to the PersistentLevel. No adds the object to TheWorld", "To PersistentLevel?");
+
+            AddStreamingKismet(pew.Pcc, filename, inPersistentLevel);
+
+            ShowSuccess($"{filename} streaming kismet added to {(inPersistentLevel ? "the PersistentLevel" : "TheWorld")}");
+        }
+
+        /// <summary>
+        /// Set the loading and streaming of the given file name in all the BioTriggerStreams where the conditional file is present.
+        /// </summary>
+        /// <param name="pew">Current PE window</param>
+        public static void StreamFileExperiment(PackageEditorWindow pew)
+        {
+            if (pew.Pcc == null) { return; }
+
+            string filename = PromptForStr("Name of file to stream:", "Not a valid file name.");
+            if (string.IsNullOrEmpty(filename))
+            {
+                ShowError("Not a valid file name.");
+                return;
+            }
+            string conditionalFile = PromptForStr("Name of conditional file:", "Not a valid file name.");
+            if (string.IsNullOrEmpty(conditionalFile))
+            {
+                ShowError("Not a valid file name.");
+                return;
+            }
+
+            StreamFile(pew.Pcc, filename, conditionalFile);
+
+            ShowSuccess($"Added loading and streaming for {filename} wherever {conditionalFile} is present");
+        }
+
         // HELPER FUNCTIONS
         #region Helper functions
         /// <summary>
         /// Indicates a class that is related to the audio elements of a BioConversation.
         /// </summary>
-        private enum AudioClass { WwiseStream, WwiseEvent, SoundCue, SoundNodeWave }
-        
-        /// <summary>
-        /// Checks if a dest position is within a given distance of the origin.
-        /// </summary>
-        /// <param name="origin">Origin position.</param>
-        /// <param name="dest">Dest position to check.</param>
-        /// <param name="dist">Max distance from origin.</param>
-        /// <returns>True if the dest is within dist</returns>
-        private static bool InDist(float origin, float dest, float dist)
+        private enum AudioClass
         {
-            return Math.Abs((dest - origin)) <= dist;
-        }
-
-        /// <summary>
-        /// Generate a default ExpressionGUID
-        /// </summary>
-        /// <returns>ExpressionGUID StructProperty</returns>
-        private static StructProperty GenerateExpressionGUID()
-        {
-            PropertyCollection props = new PropertyCollection();
-            props.Add(new IntProperty(0, "A"));
-            props.Add(new IntProperty(0, "B"));
-            props.Add(new IntProperty(0, "C"));
-            props.Add(new IntProperty(0, "D"));
-
-            return new StructProperty("Guid", props, "ExpressionGUID", true);
-        }
-
-        private static void ShowError(string errMsg)
-        {
-            MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
-        }
-
-        /// <summary>
-        /// Prompts the user for an int, verifying that the int is valid.
-        /// </summary>
-        /// <param name="msg">Message to display for the prompt.</param>
-        /// <param name="err">Error message to display.</param>
-        /// <param name="biggerThan">Number the input must be bigger than. If not provided -2,147,483,648 will be used.</param>
-        /// <param name="title">Title for the prompt.</param>
-        /// <returns>The input int.</returns>
-        private static int promptForInt(string msg, string err, int biggerThan = -2147483648, string title = "")
-        {
-            if (PromptDialog.Prompt(null, msg, title) is string stringPrompt)
-            {
-                int intPrompt;
-                if (string.IsNullOrEmpty(stringPrompt) || !int.TryParse(stringPrompt, out intPrompt) || !(intPrompt > biggerThan))
-                {
-                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
-                    return -1;
-                }
-                return intPrompt;
-            }
-            return -1;
-        }
-
-        /// <summary>
-        /// Gets the common prefix of two strings. Assumes both only difer at the end.
-        /// </summary>
-        /// <param name="s1">First string.</param>
-        /// <param name="s2">Second string.</param>
-        /// <returns>Union of input strings.</returns>
-        private static string GetCommonPrefix(string s1, string s2)
-        {
-            if (s1.Length == 0 || s2.Length == 0 || char.ToLower(s1[0]) != char.ToLower(s2[0]))
-            {
-                return "";
-            }
-
-            for (int i = 1; i < s1.Length && i < s2.Length; i++)
-            {
-                if (char.ToLower(s1[i]) != char.ToLower(s2[i]))
-                {
-                    return s1[..i];
-                }
-            }
-
-            return s1.Length < s2.Length ? s1 : s2;
-        }
-
-        /// <summary>
-        /// Calculates the FNV132 hash of the given string.
-        /// IMPORTANT: This may not be compeletely bug-free or may be missing a couple of details, but so far it works.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns>The decimal representation of the hash.</returns>
-        private static uint CalculateFNV132Hash(string name)
-        {
-            byte[] bytedName = Encoding.ASCII.GetBytes(name.ToLower()); // Wwise automatically lowecases the input
-
-            // FNV132 hashing algorithm
-            uint hash = 2166136261;
-            foreach (byte namebyte in bytedName)
-            {
-                hash = ((hash * 16777619) ^ namebyte) & 0xFFFFFFFF;
-            }
-            return hash;
-        }
-
-        /// <summary>
-        /// Create a var link with custom properties.
-        /// </summary>
-        /// <param name="pcc">Pcc to operate on.</param>
-        /// <param name="name">LinkDesc.</param>
-        /// <returns>The varLink StructProperty.</returns>
-        private static StructProperty CreateVarLink(IMEPackage pcc, string name)
-        {
-            PropertyCollection props = GlobalUnrealObjectInfo.getDefaultStructValue(pcc.Game, "SeqVarLink", true);
-
-            int minVars = name == "Anchor" ? 1 : 0;
-            int maxVars = name == "Anchor" ? 1 : 255;
-
-            props.AddOrReplaceProp(new StrProperty(name, "LinkDesc"));
-            int index = pcc.FindImport("Engine.SeqVar_Object").UIndex;
-            props.AddOrReplaceProp(new ObjectProperty(index, "ExpectedType"));
-            props.AddOrReplaceProp(new IntProperty(minVars, "MinVars"));
-            props.AddOrReplaceProp(new IntProperty(maxVars, "MaxVars"));
-            return new StructProperty("SeqVarLink", props);
+            WwiseStream, WwiseEvent, SoundCue, SoundNodeWave
         }
         #endregion
     }

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Sequence Editor/Experiments/SequenceEditorExperimentsE.cs
@@ -10,6 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using static LegendaryExplorerCore.Kismet.KismetHelper;
+using static LegendaryExplorer.Misc.ExperimentsTools.SharedMethods;
 
 namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
 {
@@ -196,7 +198,7 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
         {
             if (sew.Pcc == null || sew.SelectedSequence == null) { return; }
 
-            string camActor = promptForActor($"Name of camera actor to {(wantDir ? "control" : "add")}:", "Not a valid camera actor name.");
+            string camActor = PromptForStr($"Name of camera actor to {(wantDir ? "control" : "add")}:", "Not a valid camera actor name.");
 
             PackageCache cache = new();
 
@@ -246,25 +248,6 @@ namespace LegendaryExplorer.Tools.Sequence_Editor.Experiments
             }
 
             MessageBox.Show($"Added dialogue wheel {(wantDir ? "director" : "camera")} template", "Success", MessageBoxButton.OK);
-        }
-
-        private static void ShowError(string errMsg)
-        {
-            MessageBox.Show(errMsg, "Warning", MessageBoxButton.OK);
-        }
-
-        private static string promptForActor(string msg, string err)
-        {
-            if (PromptDialog.Prompt(null, msg) is string actor)
-            {
-                if (string.IsNullOrEmpty(actor))
-                {
-                    MessageBox.Show(err, "Warning", MessageBoxButton.OK);
-                    return null;
-                }
-                return actor;
-            }
-            return null;
         }
     }
 }

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/FaceFXAnimSetEditorControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/FaceFXAnimSetEditorControl.xaml.cs
@@ -905,7 +905,7 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
             UpdateAnimListBox();
         }
 
-        private struct LineSection
+        public struct LineSection
         {
             //don't alter capitalization of these fields, since that will break deserialization.
             public float span;

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml
@@ -183,6 +183,14 @@
         <MenuItem Header="Rename Conversation" Click="RenameConversation_Click" ToolTip="Rename a conversation, changing the WwiseBank name and FXAs and related elements too, and optionally, updating its WwiseBank ID."/>
         <MenuItem Header="Update class properties of AmbPerfGameData" Click="UpdateAmbPerfClass_Click" ToolTip="Update WepPropClass, PropName, and PropResource props of an AmbPerf."/>
         <MenuItem Header="Batch update class properties of AmbPerfGameDatas" Click="BatchUpdateAmbPerfClass_Click" ToolTip="Batch update WepPropClass, PropName, and PropResource props of an AmbPerfs in a selected Package."/>
+        <MenuItem Header="Replace 1D lightMap colors" Click="Replace1DLightMapColors_Click" ToolTip="Replaces the colors in the DirectionalSamples of the 1D Lightmap of a StaticMeshComponent"/>
+        <MenuItem Header="Replace 1D lightMap colors of exports" Click="Replace1DLightMapColorsOfExports_Click" ToolTip="Replaces the colors in the DirectionalSamples of the 1D Lightmap of the StaticMeshComponent of the given export IDs."/>
+        <MenuItem Header="Batch replace 1D lightMap colors" Click="BatchReplace1DLightMapColors_Click" ToolTip="Replaces the colors in the DirectionalSamples of the 1D Lightmap of all StaticMeshComponent"/>
+        <MenuItem Header="Add ForcedExport flags to descendants" Click="MakeExportsForced_Click" ToolTip="Adds the ForcedExport flag to all descendant exports of the selected export, including itself."/>
+        <MenuItem Header="Collect StaticMeshComponents into StaticMeshCollectionActor" Click="CollectSMCsintoSMCA_Click" ToolTip="Collect all StaticMeshComponents, referenced by StatichMeshActors, and add them into a new StaticMeshCollectionActor"/>
+        <MenuItem Header="Add Prefab to Level" Click="AddPrefabToLevel_Click" ToolTip="Creates instances of all the prefab archetypes of a Prefab into the file's persistent level."/>
+        <MenuItem Header="Add Streaming Kismet" Click="AddStreamingKismet_Click" ToolTip="Adds a level streaming kismet to either TheWorld or PersistentLevel."/>
+        <MenuItem Header="Stream File" Click="StreamFile_Click" ToolTip="Set the loading and streaming of the given file name in all the BioTriggerStreams where the conditional file is present."/>
     </MenuItem>
     <MenuItem Header="Object Database">
         <MenuItem Header="Build ME1 Object Database" Click="ChonkyDB_BuildME1GameDB"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/PackageEditorControls/ExperimentsMenuControl.xaml.cs
@@ -1471,6 +1471,46 @@ namespace LegendaryExplorer.UserControls.PackageEditorControls
         {
             PackageEditorExperimentsO.BatchUpdateAmbPerfClassExperiment(GetPEWindow());
         }
+
+        private void Replace1DLightMapColors_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.Replace1DLightMapColors(GetPEWindow());
+        } 
+
+        private void Replace1DLightMapColorsOfExports_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.Replace1DLightMapColorsOfExports(GetPEWindow());
+        } 
+
+        private void BatchReplace1DLightMapColors_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.BatchReplace1DLightMapColors(GetPEWindow());
+        }
+
+        private void MakeExportsForced_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.MakeExportsForced(GetPEWindow());
+        }
+
+        private void CollectSMCsintoSMCA_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.CollectSMCsintoSMCA(GetPEWindow());
+        }
+
+        private void AddPrefabToLevel_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.AddPrefabToLevel(GetPEWindow());
+        }
+
+        private void AddStreamingKismet_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.AddStreamingKismetExperiment(GetPEWindow());
+        }
+
+        private void StreamFile_Click(object sender, RoutedEventArgs e)
+        {
+            PackageEditorExperimentsO.StreamFileExperiment(GetPEWindow());
+        }
         #endregion
 
         // EXPERIMENTS: CHONKY DB---------------------------------------------------------

--- a/LegendaryExplorer/LegendaryExplorerCore/Dialogue/ConversationExtended.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Dialogue/ConversationExtended.cs
@@ -331,7 +331,7 @@ namespace LegendaryExplorerCore.Dialogue
         /// <param name="nodesSearched">List of nodes already visited</param>
         /// <param name="searchDepthRemaining">How many layers deep should be searched</param>
         /// <returns>Export of class SeqAct_Interp, or null if not found</returns>
-        private ExportEntry recursiveFindSeqActInterp(List<ExportEntry> nodesToSearch, List<ExportEntry> nodesSearched, int searchDepthRemaining)
+        public ExportEntry recursiveFindSeqActInterp(List<ExportEntry> nodesToSearch, List<ExportEntry> nodesSearched, int searchDepthRemaining)
         {
             if (searchDepthRemaining <= 0)
                 return null; // NOT FOUND, NO FURTHER SEARCH
@@ -480,6 +480,7 @@ namespace LegendaryExplorerCore.Dialogue
             int linestrref = 0;
             int spkridx = -2;
             int cond = -1;
+            int param = 0;
             string line = "Unknown Reference";
             int stevent = -1;
             bool bcond = false;
@@ -489,6 +490,7 @@ namespace LegendaryExplorerCore.Dialogue
                 linestrref = node.GetProp<StringRefProperty>("srText")?.Value ?? 0;
                 line = tlkLookupFunc?.Invoke(linestrref, Export.FileRef);
                 cond = node.GetProp<IntProperty>("nConditionalFunc")?.Value ?? -1;
+                param = node.GetProp<IntProperty>("nConditionalParam")?.Value ?? 0;
                 stevent = node.GetProp<IntProperty>("nStateTransition")?.Value ?? -1;
                 bcond = node.GetProp<BoolProperty>("bFireConditional");
                 if (isReply)
@@ -500,7 +502,7 @@ namespace LegendaryExplorerCore.Dialogue
                     spkridx = node.GetProp<IntProperty>("nSpeakerIndex");
                 }
 
-                return new DialogueNodeExtended(node, isReply, count, spkridx, linestrref, line, bcond, cond, stevent, eReply);
+                return new DialogueNodeExtended(node, isReply, count, spkridx, linestrref, line, bcond, cond, stevent, eReply, param);
             }
             catch (Exception e)
             {

--- a/LegendaryExplorer/LegendaryExplorerCore/Dialogue/DialogueNodeExtended.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Dialogue/DialogueNodeExtended.cs
@@ -97,7 +97,8 @@ namespace LegendaryExplorerCore.Dialogue
         /// <param name="conditionalOrBool">The nConditionalFunc value of this node</param>
         /// <param name="transition">The nStateTransition value of this node</param>
         /// <param name="replyType">The ReplyType value of this node</param>
-        public DialogueNodeExtended(StructProperty nodeProp, bool isReply, int nodeCount, int speakerIndex, int lineStrRef, string line, bool firesConditional, int conditionalOrBool, int transition, EReplyTypes replyType)
+        /// <param name="conditionalParam">The ConditionalParam value of this node</param>
+        public DialogueNodeExtended(StructProperty nodeProp, bool isReply, int nodeCount, int speakerIndex, int lineStrRef, string line, bool firesConditional, int conditionalOrBool, int transition, EReplyTypes replyType, int conditionalParam = 0)
         {
             NodeProp = nodeProp;
             IsReply = isReply;
@@ -107,6 +108,7 @@ namespace LegendaryExplorerCore.Dialogue
             Line = line;
             FiresConditional = firesConditional;
             ConditionalOrBool = conditionalOrBool;
+            ConditionalParam = conditionalParam;
             Transition = transition;
             ReplyType = replyType;
         }

--- a/LegendaryExplorer/LegendaryExplorerCore/Matinee/MatineeHelper.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Matinee/MatineeHelper.cs
@@ -424,5 +424,67 @@ namespace LegendaryExplorerCore.Matinee
             }
             return props;
         }
+
+        /// <summary>
+        /// Try get an InterpGroup in an InterpData by groupName.
+        /// </summary>
+        /// <param name="interpData">InterpData to search on.</param>
+        /// <param name="groupName">Group name to find.</param>
+        /// <param name="interpGroup">Target InterpGroup.</param>
+        /// <returns>Whether the InterpGroup was found or not.</returns>
+        public static bool TryGetInterpGroup(ExportEntry interpData, string groupName, out ExportEntry interpGroup)
+        {
+            interpGroup = null;
+            IMEPackage pcc = interpData.FileRef;
+
+            ArrayProperty<ObjectProperty> interpGroups = interpData.GetProperty<ArrayProperty<ObjectProperty>>("InterpGroups");
+            if (interpGroups == null) { return false; }
+
+            foreach (ObjectProperty groupRef in interpGroups)
+            {
+                if (!pcc.TryGetUExport(groupRef.Value, out ExportEntry group)) { continue; }
+
+                // Skip non Conversation groups
+                NameProperty GroupName = group.GetProperty<NameProperty>("GroupName");
+                if (GroupName != null && GroupName.Value == groupName)
+                {
+                    interpGroup = group;
+                    break;
+                }
+            }
+
+            return interpGroup != null;
+        }
+
+        /// <summary>
+        /// Try get an InterpTrack in an InterpGroup by trackClass.
+        /// </summary>
+        /// <param name="interpGroup">InterpGroup to search on.</param>
+        /// <param name="trackClass">Class of the track to find.</param>
+        /// <param name="interpTrack">Target InterpTrack.</param>
+        /// <returns>Whether the InterpTrack was found or not.</returns>
+        public static bool TryGetInterpTrack(ExportEntry interpGroup, string trackClass, out ExportEntry interpTrack)
+        {
+            interpTrack = null;
+            IMEPackage pcc = interpGroup.FileRef;
+
+            ArrayProperty<ObjectProperty> interpTracks = interpGroup.GetProperty<ArrayProperty<ObjectProperty>>("InterpTracks");
+            if (interpTracks == null) { return false; }
+
+            foreach (ObjectProperty trackRef in interpTracks)
+            {
+                if (!pcc.TryGetUExport(trackRef.Value, out ExportEntry track)) { continue; }
+
+                // Find the VO track
+                if (track.ClassName == trackClass)
+                {
+                    interpTrack = track;
+                    break;
+                }
+            }
+
+            return interpTrack != null;
+
+        }
     }
 }


### PR DESCRIPTION
Add multiple experiments to the Package, Dialogue, and Interp Editors that I have written since last year.
There may be a style difference between the older and the newer written methods, as I coded this PR over a year, more or less.
I also recently abstracted repeated code to new separate files, but some older experiments may not fully use this new code yet.

This is the list of new experiments added:

**Package Editor:**
- Replace 1D lightMap colors
- Replace 1D lightMap colors of exports
- Batch replace 1D lightMap colors
- Add ForcedExport flags to descendants
- Collect StaticMeshComponents into StaticMeshCollectionActor
- Add Prefab to Level
- Add Streaming Kismet
- Stream File

**Dialogue Editor:**
- Link Nodes to Free ExportIDs
- Link Nodes to ExportIds by String Reference
- Batch Create Sequence Elements for Conversation
- Create Sequence Elements for Selected Node
- Batch Update VOElements and Interp Comment of Conversation
- Update VOElements and Interp Comment for Selected Node
- Batch Add Conversation Defaults to Conversation
- Add Conversation Defaults to Selected Node
- Batch Update the InterpLenghts of the Conversation
- Update the InterpLengths of Selected Node
- Batch Generate LE1 Audio Links for Conversation
- Generate LE1 Audio Links for Selected Node
- Fix Autocontinues
- Batch unlist Track from Group
- Unlist Track from Group

**Interp Editor:**
- Insert TrackMove Key
- Delete TrackMove Key
- Insert DOF Key
- Delete DOF Key
- Insert Gesture Key
- Delete Gesture Key
- Add Preset Camera InterpGroup with TrackMove Keys
- Set Starting Pose