### PR TITLE
Shader stuff, replace one shader, export all shaders, import all shaders

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/Tools/ScriptDebugger/ScriptDebuggerWindow.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/ScriptDebugger/ScriptDebuggerWindow.xaml.cs
@@ -37,7 +37,7 @@ namespace LegendaryExplorer.Tools.ScriptDebugger
         {
             MEGame.LE1 => "LE1ScriptDebugger-v3.asi", // In M3
             MEGame.LE2 => "LE2ScriptDebugger-v3.asi", // In M3
-            MEGame.LE3 => "LE3ScriptDebugger-v3.asi",  // In M3
+            MEGame.LE3 => "LE3ScriptDebugger-v4.asi",  // In M3
             _ => throw new ArgumentOutOfRangeException(nameof(Game))
         };
         private void GetDebuggerASI()
@@ -51,7 +51,7 @@ namespace LegendaryExplorer.Tools.ScriptDebugger
                     ModManagerIntegration.RequestASIInstallation(MEGame.LE2, ASIModIDs.LE2_SCRIPT_DEBUGGER, 3);
                     break;
                 case MEGame.LE3:
-                    ModManagerIntegration.RequestASIInstallation(MEGame.LE3, ASIModIDs.LE3_SCRIPT_DEBUGGER, 3);
+                    ModManagerIntegration.RequestASIInstallation(MEGame.LE3, ASIModIDs.LE3_SCRIPT_DEBUGGER, 4);
                     break;
             }
         }

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/MaterialViewer/MaterialExportLoader.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/MaterialViewer/MaterialExportLoader.xaml
@@ -22,6 +22,10 @@
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
                     <TextBlock Text="{Binding TopInfoText}" />
                     <Button Name="createShadersCopy_Button" Content="Create Unique Copy of Shaders" Command="{Binding CreateShadersCopyCommand, Mode=OneTime}" sharedUi:Bindings.VisibilityToEnabled="True"/>
+                    <TextBlock Name="TopShaderInfoTextBlock" Text="{Binding TopShaderInfoText}" />
+                    <Button x:Name="replaceLoadedShader_Button" Content="Replace Shader" Command="{Binding ReplaceLoadedShaderCommand, Mode=OneTime}" sharedUi:Bindings.VisibilityToEnabled="True"/>
+                    <Button x:Name="ExportAllShaders_Button" Content="Export Shaders" Command="{Binding ExportAllShadersCommand, Mode=OneTime}" sharedUi:Bindings.VisibilityToEnabled="True"/>
+                    <Button x:Name="ImportAllShaders_Button" Content="Import Shaders" Command="{Binding ImportAllShadersCommand, Mode=OneTime}" sharedUi:Bindings.VisibilityToEnabled="True"/>
                 </StackPanel>
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/LegendaryExplorer/LegendaryExplorerCore.Tests/CoalescedTests.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore.Tests/CoalescedTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using LegendaryExplorerCore.Coalesced;
+using LegendaryExplorerCore.Helpers;
 using LegendaryExplorerCore.Packages;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -41,7 +42,7 @@ namespace LegendaryExplorerCore.Tests
                 else
                 {
                     var decomp1 = CoalescedConverter.DecompileLE1LE2ToMemory(fs, "");
-                    var recomp1 = CoalescedConverter.CompileLE1LE2FromMemory(decomp1);
+                    var recomp1 = CoalescedConverter.CompileLE1LE2FromMemory(decomp1, coalBin.GetUnrealLocalization());
                     var decomp2 = CoalescedConverter.DecompileLE1LE2ToMemory(recomp1, "");
 
                     // Compare
@@ -49,6 +50,17 @@ namespace LegendaryExplorerCore.Tests
                     {
                         var pairValue2 = decomp2[pair1.Key].ToString();
                         Assert.AreEqual(pair1.Value.ToString(), pairValue2, $"Decompilation/recomp/re-decomp failed for coalesced file! Results are not identical. File: {coalBin}. Subfile: {pair1.Key}");
+                    }
+
+                    // Test internal name serialization
+                    fs.Position = 0;
+                    recomp1.Position = 0;
+                    var originalNames = LECoalescedConverter.GetInternalFilePaths(fs);
+                    var newNames = LECoalescedConverter.GetInternalFilePaths(recomp1);
+
+                    for (int i = 0; i < originalNames.Count; i++)
+                    {
+                        Assert.IsTrue(originalNames[i].CaseInsensitiveEquals(newNames[i]), $"LECoalesced serialization produced different internal paths: Expected: {originalNames[i]}, Got: {newNames[i]}");
                     }
                 }
             }

--- a/LegendaryExplorer/LegendaryExplorerCore/Coalesced/CoalescedConverter.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Coalesced/CoalescedConverter.cs
@@ -36,12 +36,16 @@ namespace LegendaryExplorerCore.Coalesced
                 "BioCompat",
                 "BioCredits",
                 "BioDifficulty",
-                "BioEditor",
+                "BioEditor", // LE1
+                "BioEditorKeyBindings", // LE1
+                "BIoEditorUserSettings", // LE1
                 "BioEngine",
                 "BioGame",
                 "BioGuiResources", // PC Main Menu PC New Character
                 "BioInput",
                 "BioLightmass",
+                "BioParty", // LE1
+                "BioStringTypeMap", // LE1
                 "BioTest",
                 "BioUI",
                 "BioQA",

--- a/LegendaryExplorer/LegendaryExplorerCore/Coalesced/CoalescedConverter.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Coalesced/CoalescedConverter.cs
@@ -36,6 +36,7 @@ namespace LegendaryExplorerCore.Coalesced
                 "BioCompat",
                 "BioCredits",
                 "BioDifficulty",
+                "BioEditor",
                 "BioEngine",
                 "BioGame",
                 "BioGuiResources", // PC Main Menu PC New Character

--- a/LegendaryExplorer/LegendaryExplorerCore/Coalesced/LECoalesced.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Coalesced/LECoalesced.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Xml.Linq;
 using LegendaryExplorerCore.Helpers;
 using LegendaryExplorerCore.Misc;
 using LegendaryExplorerCore.Packages;
@@ -133,7 +134,7 @@ namespace LegendaryExplorerCore.Coalesced
             return bundle;
         }
 
-        private static DuplicatingIni ReadCoalescedIni(BinaryReader reader, int sectionCount)
+        internal static DuplicatingIni ReadCoalescedIni(BinaryReader reader, int sectionCount)
         {
             DuplicatingIni ini = new DuplicatingIni();
             DuplicatingIni.Section s = null;
@@ -350,7 +351,7 @@ namespace LegendaryExplorerCore.Coalesced
                 case ".pol":
                 case ".fra":
                 case "" when CoalescedConverter.LocalizedFiles.Contains(fNameNoExt, StringComparer.OrdinalIgnoreCase): // No extension, may have been stripped
-                    return $@"..\..\Localization\{localization.ToString().ToUpper()}\{fNameNoExt}.{localization.ToString().ToLower()}";
+                    return $@"..\..\Engine\Localization\{localization.ToString().ToUpper()}\{fNameNoExt}.{localization.ToString().ToLower()}";
                 case ".ini":
                     return $@"..\..\BIOGame\Config\{filename}";
                 case "" when CoalescedConverter.ProperNames.Contains(fNameNoExt, StringComparer.OrdinalIgnoreCase): // No extension, may have been stripped
@@ -386,6 +387,24 @@ namespace LegendaryExplorerCore.Coalesced
         public static LECoalescedBundle UnpackToMemory(Stream stream, string name)
         {
             return LECoalescedBundle.ReadFromStream(stream, name);
+        }
+
+        // This is for test cases
+        public static List<string> GetInternalFilePaths(Stream stream)
+        {
+            List<string> names = new List<string>();
+
+            BinaryReader reader = new BinaryReader(stream);
+            var fileCount = reader.ReadInt32();
+
+            for (int i = 0; i < fileCount; i++)
+            {
+                names.Add(reader.ReadCoalescedString());
+                var sectionCount = reader.ReadInt32();
+                LECoalescedBundle.ReadCoalescedIni(reader, sectionCount);
+            }
+
+            return names;
         }
 
         /// <summary>

--- a/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/ShaderCache.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/ShaderCache.cs
@@ -5,6 +5,7 @@ using LegendaryExplorerCore.Helpers;
 using LegendaryExplorerCore.Packages;
 using LegendaryExplorerCore.Shaders;
 using LegendaryExplorerCore.Unreal.Collections;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace LegendaryExplorerCore.Unreal.BinaryConverters
 {
@@ -163,6 +164,16 @@ namespace LegendaryExplorerCore.Unreal.BinaryConverters
                 unkBytes = unkBytes.ArrayClone()
             };
             return newShader;
+        }
+        
+        // replace shader bytes
+        public void Replace(byte[] newShaderByteCode)
+        {
+            // insert new binary
+            ShaderByteCode = newShaderByteCode;
+
+            // return
+            return;
         }
     }
 


### PR DESCRIPTION
pretty scuffed code, including the derpy commits....

a bit of rundown:
replace shader just replaces the bytecode of one selected shader in the shader view (have to actually click on the specific shader and look at top to see if GUID updates, then it should be safe to replace that one shader)

export all shaders grabs all shader files from selected material and exports them as .FXC file with some naming convetion that sets the file name: shaderID_shaderType_shaderPolicy . fxc

import all shaders looks for .fxc files inside a folder, using the same name convention as in the export all shaders (so it replaces correct shaders), with addition of expected _edited tag at the end of file name: shaderID_shaderType_shaderPolicy_edited . fxc