### PR TITLE
ME1/Xenon reading tweaks.

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/BinaryInterpreter/BinaryInterpreterScans.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/BinaryInterpreter/BinaryInterpreterScans.cs
@@ -4487,7 +4487,10 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
                 }
 
                 int cachedPhysBSPDataSize;
-                subnodes.Add(MakeInt32Node(bin, "size of byte"));
+                if (!(Pcc.Game == MEGame.ME1 && Pcc.Platform == MEPackage.GamePlatform.Xenon))
+                {
+                    subnodes.Add(MakeInt32Node(bin, "size of byte"));
+                }
                 subnodes.Add(new BinInterpNode(bin.Position, $"CachedPhysBSPData Size: {cachedPhysBSPDataSize = bin.ReadInt32()}"));
                 if (cachedPhysBSPDataSize > 0)
                 {

--- a/LegendaryExplorer/LegendaryExplorerCore/TLK/ME1/ME1TalkFile.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/TLK/ME1/ME1TalkFile.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -292,8 +293,9 @@ namespace LegendaryExplorerCore.TLK.ME1
             while (offset * 8 < bits.Length)
             {
                 int size = BitConverter.ToInt32(data, offset);
+                if (!r.Endian.IsNative) size = BinaryPrimitives.ReverseEndianness(size);
                 offset += 4;
-                string s = GetString(offset * 8, bits);
+                string s = GetString(offset * 8, bits, swapEndian: !r.Endian.IsNative);
                 offset += size + 4;
                 rawStrings.Add(s);
             }
@@ -308,7 +310,7 @@ namespace LegendaryExplorerCore.TLK.ME1
             }
         }
 
-        private string GetString(int bitOffset, TLKBitArray bits)
+        private string GetString(int bitOffset, TLKBitArray bits, bool swapEndian = false)
         {
             HuffmanNode root = nodes[0];
             HuffmanNode curNode = root;
@@ -332,6 +334,7 @@ namespace LegendaryExplorerCore.TLK.ME1
                 /* it's a leaf! */
                 {
                     char c = curNode.Data;
+                    if (swapEndian) c = (char)BinaryPrimitives.ReverseEndianness((short)c);
                     if (c != '\0')
                     {
                         /* it's not NULL */

--- a/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/Level.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/Level.cs
@@ -75,8 +75,12 @@ namespace LegendaryExplorerCore.Unreal.BinaryConverters
                 ApexMesh = [];
             }
 
-            int byteSize = 1;
-            sc.Serialize(ref byteSize);
+            if (!(sc.Game == MEGame.ME1 && sc.Pcc.Platform == MEPackage.GamePlatform.Xenon))
+            {
+                int byteSize = 1;
+                sc.Serialize(ref byteSize);
+            }
+
             sc.Serialize(ref CachedPhysBSPData);
 
             sc.Serialize(ref CachedPhysSMDataMap, sc.Serialize, sc.Serialize);


### PR DESCRIPTION
Some (old) minor fixes to improve deserialization of ME1 Xenon assets.
Currently, only fixes TLK reading.