### PR TITLE
Fix ability to save hex edits in Wwise Graph Editor

### DIFF
--- a/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/WwiseBank.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/WwiseBank.cs
@@ -183,20 +183,15 @@ namespace LegendaryExplorerCore.Unreal.BinaryConverters
             //}
             //else
             //{
-                if (sc.IsLoading)
-                {
-                    ReadChunks(sc);
-                }
-            //    else
-            //    {
-            //        // Commented out
-            //        //WriteChunks(sc);
-            //        //var endPos = sc.ms.Position;
-            //        //sc.ms.JumpTo(dataSizePos);
-            //        //sc.ms.Writer.WriteInt32((int)(endPos - dataSizePos - 12));
-            //        //sc.ms.Writer.WriteInt32((int)(endPos - dataSizePos - 12));
-            //        //sc.ms.JumpTo(endPos);
-            //    }
+            if (sc.IsLoading)
+            {
+                ReadChunks(sc);
+            }
+            else
+            {
+                // When saving, write all chunks (embedded files, HIRC, etc.) so changes are persisted.
+                WriteChunks(sc);
+            }
             //}
         }
 

--- a/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/WwiseBank.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Unreal/BinaryConverters/WwiseBank.cs
@@ -137,6 +137,7 @@ namespace LegendaryExplorerCore.Unreal.BinaryConverters
             base.Serialize(sc);
 
             sc.ms.Position -= BnkFile.Length; // Reset back to BnkFile offset for parsing.
+            long dataSizePos = sc.ms.Position - 12; // Position of the first bulk data size field.
 
             if (sc.IsLoading)
             {
@@ -189,8 +190,13 @@ namespace LegendaryExplorerCore.Unreal.BinaryConverters
             }
             else
             {
-                // When saving, write all chunks (embedded files, HIRC, etc.) so changes are persisted.
                 WriteChunks(sc);
+
+                var endPos = sc.ms.Position;
+                sc.ms.JumpTo(dataSizePos);
+                sc.ms.Writer.WriteInt32((int)(endPos - dataSizePos - 12));
+                sc.ms.Writer.WriteInt32((int)(endPos - dataSizePos - 12));
+                sc.ms.JumpTo(endPos);
             }
             //}
         }


### PR DESCRIPTION
restores commented out code so that changes can now be properly saved again.