### PR TITLE
small changes to shader cache binary interpreter for readability

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/BinaryInterpreter/BinaryInterpreterScans.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/BinaryInterpreter/BinaryInterpreterScans.cs
@@ -49,7 +49,8 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
         private BinInterpNode ReadMaterialUniformExpression(EndianReader bin, string prefix = "")
         {
             NameReference expressionType = bin.ReadNameReference(Pcc);
-            var node = new BinInterpNode(bin.Position - 8, $"{prefix}{(string.IsNullOrEmpty(prefix) ? "" : ": ")}{expressionType.Instanced}");
+            string parameterName;
+            var node = new BinInterpNode(bin.Position - 8, $"{prefix}{(string.IsNullOrEmpty(prefix) ? "" : ": ")}{expressionType.Instanced}") { Length = 8 };
 
             switch (expressionType.Name)
             {
@@ -93,7 +94,9 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
                     //intentionally left blank. outputs current real-time, has no parameters
                     break;
                 case "FMaterialUniformExpressionScalarParameter":
-                    node.Items.Add(new BinInterpNode(bin.Position, $"ParameterName: {bin.ReadNameReference(Pcc).Instanced}"));
+                    parameterName = bin.ReadNameReference(Pcc).Instanced;
+                    node.Header += $" ({parameterName})";
+                    node.Items.Add(new BinInterpNode(bin.Position - 8, $"ParameterName: {parameterName}") { Length = 8 });
                     node.Items.Add(MakeFloatNode(bin, "DefaultValue"));
                     break;
                 case "FMaterialUniformExpressionSine":
@@ -116,14 +119,18 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
                     node.Items.Add(MakeEntryNode(bin, "TextureIndex"));
                     break;
                 case "FMaterialUniformExpressionTextureParameter":
-                    node.Items.Add(new BinInterpNode(bin.Position, $"ParameterName: {bin.ReadNameReference(Pcc).Instanced}"));
+                    parameterName = bin.ReadNameReference(Pcc).Instanced;
+                    node.Header += $" ({parameterName})";
+                    node.Items.Add(new BinInterpNode(bin.Position - 8, $"ParameterName: {parameterName}") { Length = 8 });
                     node.Items.Add(MakeInt32Node(bin, "TextureIndex"));
                     break;
                 case "FMaterialUniformExpressionTime":
                     //intentionally left blank. outputs current scene time, has no parameters
                     break;
                 case "FMaterialUniformExpressionVectorParameter":
-                    node.Items.Add(new BinInterpNode(bin.Position, $"ParameterName: {bin.ReadNameReference(Pcc).Instanced}"));
+                    parameterName = bin.ReadNameReference(Pcc).Instanced;
+                    node.Header += $" ({parameterName})";
+                    node.Items.Add(new BinInterpNode(bin.Position - 8, $"ParameterName: {parameterName}") { Length = 8 });
                     node.Items.Add(MakeFloatNode(bin, "Default R"));
                     node.Items.Add(MakeFloatNode(bin, "Default G"));
                     node.Items.Add(MakeFloatNode(bin, "Default B"));

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/BinaryInterpreter/ShaderCacheScans.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/BinaryInterpreter/ShaderCacheScans.cs
@@ -1679,7 +1679,7 @@ public partial class BinaryInterpreterWPF
                 [
                     MakeInt32Node(bin, "unk int 1"),
                     MakeBoolIntNode(bin, "UniformPixelShaderParameters is well formed?"),
-                    MakeInt32Node(bin, "unk int 2")
+                    MakeInt32Node(bin, "UniformPixelScalarShaderParameterCount")
                 ]);
             }
             super.Items.Add(FShaderParameter("WrapLightingParameters"));
@@ -1712,7 +1712,14 @@ public partial class BinaryInterpreterWPF
             }
             else
             {
-                return parameter($"(Type {bin.ReadByte()}) [{bin.ReadInt32()}]");
+                byte paramType = bin.ReadByte();
+                string paramTypePretty = $"(Type {paramType})";
+                if (paramType == 8) { paramTypePretty = "UniformPixelVectorShaderParameter"; }
+                else if (paramType == 15) { paramTypePretty = "UniformPixelScalarShaderParameter"; }
+                else if (paramType == 16) { paramTypePretty = "UniformPixel2DShaderResourceParameter"; }
+                else if (paramType == 32) { paramTypePretty = "UniformPixelCubeShaderResourceParameter"; }
+
+                return parameter($"{paramTypePretty} [{bin.ReadInt32()}]");
             }
         }
 


### PR DESCRIPTION
This PR contains these little changes to binary interpreter for shader cache

### 1. Change unk int 2 to "UniformPixelScalarShaderParameterCount" :
Named by me, should be explanatory enough, the int represents amount of scalar parameters inside uniform pixel shader parameters array.

### 2. display named parameter names inside the headers for easier lookup inside shader map :
<img width="622" height="468" alt="image" src="https://github.com/user-attachments/assets/94782e60-177a-46f9-ac9b-e3690d1df307" />

### 3. display names of uniform parameter types inside embeded shader files instead of (Type 15) etc :
<img width="636" height="350" alt="image" src="https://github.com/user-attachments/assets/22e21523-1f9d-46c3-a4f1-27ac3e3edf0a" />
