### PR TITLE
PackageEditor: Compare package to installed package

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/Packages/SharedPackageTools.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Packages/SharedPackageTools.cs
@@ -190,6 +190,66 @@ namespace LegendaryExplorer.Packages
             }
         }
 
+        public static void ComparePackageToInstalledPackage(WPFBase wpfBase, Action<EntryStringPair> entryDoubleClickCallback, bool structuralCompare = false)
+        {
+            // no pcc no joy
+            if (wpfBase?.Pcc == null) return;
+
+            if (!wpfBase.Pcc.Game.IsMEGame())
+            {
+                MessageBox.Show(wpfBase, "Can only compare packages from the Original Trilogy or Legendary Edition.",
+                    "Can't compare", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            Task.Run(() =>
+            {
+                wpfBase.BusyText = "Finding installed candidates...";
+                wpfBase.IsBusy = true;
+
+                CaseInsensitiveDictionary<string> dlcFiles = [];
+
+                string pccFileName = Path.GetFileName(wpfBase.Pcc.FilePath);
+                foreach (string file in MELoadedFiles.GetAllGameFiles(null, wpfBase.Pcc.Game))
+                {
+                    string fileName = Path.GetFileName(file);
+                    if (fileName == null) continue;
+                    if (fileName != pccFileName) continue; // only files of same name
+                    if (file == wpfBase.Pcc.FilePath) continue; // skip same file as current opened
+
+                    string dlcFolder = file.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                        .FirstOrDefault(p => p.StartsWith("DLC_"));
+                    dlcFolder ??= "basegame";
+
+                    // save file
+                    dlcFiles.Add(dlcFolder, file);
+                }
+
+                return dlcFiles;
+            }).ContinueWithOnUIThread(foundCandidates =>
+            {
+                wpfBase.IsBusy = false;
+                if (!foundCandidates.Result.Any())
+                {
+                    MessageBox.Show(wpfBase, "Cannot find any candidates for this file!");
+                    return;
+                }
+
+                var choice = InputComboBoxDialog.GetValue(wpfBase, "Choose installation source to compare to:",
+                    "Installed file comparison", foundCandidates.Result.Keys, foundCandidates.Result.Keys.Last());
+                if (string.IsNullOrEmpty(choice)) return;
+
+                foundCandidates.Result.TryGetValue(choice, out string selectedFile);
+                if (selectedFile == null)
+                {
+                    MessageBox.Show("Selected candidate not found in the lists! This is a bug", "OH NO");
+                    return;
+                }
+
+                CompareToPackageWrapper(wpfBase, entryDoubleClickCallback, structuralCompare: structuralCompare, diskPath: selectedFile);
+            });
+        }
+
         public static bool CanCompareToUnmodded(WPFBase wpfBase) => wpfBase.Pcc != null && wpfBase.Pcc.Game != MEGame.UDK && (!(wpfBase.Pcc.IsInBasegame() || wpfBase.Pcc.IsInOfficialDLC()) || ME3TweaksBackups.GetGameBackupPath(wpfBase.Pcc.Game) != null);
 
         public static UnmoddedCandidatesLookup GetUnmoddedCandidatesForPackage(WPFBase wpfBase)

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/PackageEditorWindow.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/PackageEditorWindow.xaml
@@ -166,8 +166,11 @@
                 <MenuItem Header="Tools" Padding="4">
                     <MenuItem Header="Package file header info" ToolTip="View information stored in package header" Command="{Binding PackageHeaderViewerCommand}"/>
                     <MenuItem Header="LECL Data Editor" ToolTip="Edits metadata stored in this package that is used in mod development tools" Command="{Binding LECLEditorCommand}"/>
+                    <MenuItem Header="Compare with another package (installed)" ToolTip="Compare another version of this package from installed packages in the game folder to see what exports and imports have changed" Command="{Binding CompareToInstalledCommand}"/>
                     <MenuItem Header="Compare with another package" ToolTip="Compare another version of this package to see what exports and imports have changed" Command="{Binding ComparePackagesCommand}"/>
                     <MenuItem Header="Compare with unmodded" ToolTip="Compare with the (hopefully) unmodded version of this package to see what exports and imports have changed" Command="{Binding CompareToUnmoddedCommand}"/>
+                    <MenuItem Header="Structural Compare with another package (installed)" Command="{Binding StructuralCompareToInstalledCommand}"
+                              ToolTip="Compare another version of this package from installed packages in the game folder to see what exports and imports have changed. This comparison method tries to match entries based on their paths, not their indexes." />
                     <MenuItem Header="Structural Compare with another package" Command="{Binding StructuralComparePackagesCommand}"
                               ToolTip="Compare another version of this package to see what exports and imports have changed. This comparison method tries to match entries based on their paths, not their indexes." />
                     <MenuItem Header="Structural Compare with unmodded" Command="{Binding StructuralCompareToUnmoddedCommand}"

--- a/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/PackageEditorWindow.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/PackageEditor/PackageEditorWindow.xaml.cs
@@ -185,6 +185,8 @@ namespace LegendaryExplorer.Tools.PackageEditor
         public ICommand ForceReloadPackageCommand { get; set; }
         public ICommand ComparePackagesCommand { get; set; }
         public ICommand StructuralComparePackagesCommand { get; set; }
+        public ICommand CompareToInstalledCommand { get; set; }
+        public ICommand StructuralCompareToInstalledCommand { get; set; }
         public ICommand OpenOtherVersionCommand { get; set; }
         public ICommand OpenHighestMountedCommand { get; set; }
         public ICommand CompareToUnmoddedCommand { get; set; }
@@ -264,6 +266,8 @@ namespace LegendaryExplorer.Tools.PackageEditor
             StructuralCompareToUnmoddedCommand = new GenericCommand(() => SharedPackageTools.ComparePackageToUnmodded(this, entryDoubleClickToTreeview, true), () => SharedPackageTools.CanCompareToUnmodded(this));
             ComparePackagesCommand = new GenericCommand(() => SharedPackageTools.ComparePackageToAnother(this, entryDoubleClickToTreeview), PackageIsLoaded);
             StructuralComparePackagesCommand = new GenericCommand(() => SharedPackageTools.ComparePackageToAnother(this, entryDoubleClickToTreeview, true), PackageIsLoaded);
+            CompareToInstalledCommand = new GenericCommand(() => SharedPackageTools.ComparePackageToInstalledPackage(this, entryDoubleClickToTreeview), PackageIsLoaded);
+            StructuralCompareToInstalledCommand = new GenericCommand(() => SharedPackageTools.ComparePackageToInstalledPackage(this, entryDoubleClickToTreeview, true), PackageIsLoaded);
             ExportAllDataCommand = new GenericCommand(ExportAllData, ExportIsSelected);
             ExportBinaryDataCommand = new GenericCommand(ExportBinaryData, ExportIsSelected);
             ImportAllDataCommand = new GenericCommand(ImportAllData, ExportIsSelected);


### PR DESCRIPTION
add new package editor comparison option in the tools menu:

<img width="883" height="423" alt="image" src="https://github.com/user-attachments/assets/7a7ab23d-52ee-4d85-b5b9-1256d56621dc" />

this shows selection box for package comparison from files in installation:

<img width="490" height="185" alt="image" src="https://github.com/user-attachments/assets/f5e7bdea-1816-4274-8745-f5e54fbc2e42" />