### PR TITLE
Update FFDec installation detection

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/JPEXSWFExportLoader.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/JPEXSWFExportLoader.xaml.cs
@@ -53,12 +53,17 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
             if (JPEXIsInstalled) return;
             try
             {
-                using RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{E618D276-6596-41F4-8A98-447D442A77DB}_is1");
-                if (key?.GetValue("InstallLocation") is string InstallDir)
+                using RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\JPEXS\FFDec");
+                if (Convert.ToInt32(key?.GetValue("installed", 0)) == 1 &&
+                    key?.GetValue("installDir") is string installDir)
                 {
-                    JPEXExecutableLocation = Path.Combine(InstallDir, "ffdec.exe");
-                    JPEXIsInstalled = true;
-                    return;
+                    string executable = Path.Combine(installDir, "ffdec.exe");
+                    if (File.Exists(executable))
+                    {
+                        JPEXExecutableLocation = executable;
+                        JPEXIsInstalled = true;
+                        return;
+                    }
                 }
             }
             catch


### PR DESCRIPTION
Updates FFDec installation detection to use the registry key introduced in [FFDec nightly 3542](https://github.com/jindrapetrik/jpexs-decompiler/releases/tag/nightly3542).

The detection now checks:

- `HKCU\Software\JPEXS\FFDec`
- `installed == 1`
- `installDir`
- `ffdec.exe` exists in `installDir`

As of [25.0.0](https://github.com/jindrapetrik/jpexs-decompiler/releases/tag/version25.0.0), FFDec switched from an Inno Setup installer to MSI, so the Windows uninstall registry key is no longer a reliable way to detect installations because the MSI product GUID changes between versions.

Following [discussion with JPEXS](https://www.free-decompiler.com/flash/issues/2716-msi-installer-not-generating-uninstall-registry-key), this updates Legendary Explorer to use the dedicated registry key intended for installation detection instead.