### PR TITLE
Add LE1 ISACT bank authoring workflow

### DIFF
--- a/LegendaryExplorer/LegendaryExplorer.Tests/Audio/ISACTBankBuilderTests.cs
+++ b/LegendaryExplorer/LegendaryExplorer.Tests/Audio/ISACTBankBuilderTests.cs
@@ -5,17 +5,27 @@ using System.Threading.Tasks;
 using LegendaryExplorerCore;
 using LegendaryExplorerCore.Packages;
 using LegendaryExplorerCore.Sound.ISACT;
+using LegendaryExplorerCore.Unreal;
 using LegendaryExplorerCore.Unreal.BinaryConverters;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LegendaryExplorer.Tests.Audio;
 
+/// <summary>
+/// Verifies deterministic ISACT authoring, event naming, bank mutation, and LE1 package integration.
+/// </summary>
 [TestClass]
 public class ISACTBankBuilderTests
 {
+    /// <summary>
+    /// Initializes package and binary-converter services used by the package integration tests.
+    /// </summary>
     [ClassInitialize]
     public static void Initialize(TestContext _) => LegendaryExplorerCoreLib.InitLib(TaskScheduler.Default);
 
+    /// <summary>
+    /// Verifies conversation filenames create the expected samples, gendered events, and ISACT indices.
+    /// </summary>
     [TestMethod]
     public void CreateSourceBanks_BuildsExpectedSamplesAndEvents()
     {
@@ -35,6 +45,7 @@ public class ISACTBankBuilderTests
                 new[] { 0, 0, 1, 2 },
                 result.EventMappings.Select(mapping => mapping.SampleIndex).ToArray());
 
+            // Reparse both banks to verify their serialized representation rather than only the source objects.
             using var icbStream = new MemoryStream();
             result.Banks.ICBBank.Write(icbStream);
             icbStream.Position = 0;
@@ -67,6 +78,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies deterministic serialization and the shared-audio fallback for unpaired dialogue lines.
+    /// </summary>
     [TestMethod]
     public void CreateSourceBanks_IsDeterministicAndUsesSingleGenderAsSharedFallback()
     {
@@ -89,6 +103,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies conversation authoring rejects filenames without a trailing string reference.
+    /// </summary>
     [TestMethod]
     public void CreateSourceBanks_RejectsMalformedConversationName()
     {
@@ -106,6 +123,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies content-index entries are divided into the 50-entry pages used by ISACT.
+    /// </summary>
     [TestMethod]
     public void CreateSourceBanks_SplitsContentIndexAtLegacyFiftyEntryLimit()
     {
@@ -129,6 +149,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies appending preserves compiled sample data and rebases sample and event indices.
+    /// </summary>
     [TestMethod]
     public void AppendCompiledBanks_PreservesExistingSamplesAndRebasesAddedObjects()
     {
@@ -146,6 +169,7 @@ public class ISACTBankBuilderTests
                 .OfType<ISACTListBankChunk>().Single(chunk => chunk.ObjectType == "samp").SampleData.ToArray();
 
             ISACTBankPair merged = ISACTBankBuilder.AppendCompiledBanks(existing, additions);
+            // Serialize and reparse to catch incorrect chunk sizes or index data written by the merge.
             using var icbStream = new MemoryStream(Serialize(merged.ICBBank));
             using var isbStream = new MemoryStream(Serialize(merged.ISBBank));
             var reparsedIcb = new ISACTBank(icbStream);
@@ -173,6 +197,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies an append cannot introduce a Sound Event title already present in the content bank.
+    /// </summary>
     [TestMethod]
     public void AppendCompiledBanks_RejectsDuplicateEvents()
     {
@@ -195,6 +222,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies sample replacement retains the original resource identity and all unrelated payloads.
+    /// </summary>
     [TestMethod]
     public void ReplaceCompiledSample_PreservesIndexTitleAndOtherSamplePayloads()
     {
@@ -234,6 +264,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies a new BioSoundNodeWaveStreamingData export has the required hierarchy, flags, and stripped ISB.
+    /// </summary>
     [TestMethod]
     public void CreateStreamingDataExport_CreatesExportInEmptyPackage()
     {
@@ -250,6 +283,13 @@ public class ISACTBankBuilderTests
             Assert.AreEqual("BioSoundNodeWaveStreamingData", export.ClassName);
             Assert.AreEqual("native_bank", export.ObjectName.Name);
             Assert.AreEqual("DVDStreamingAudioData.PC", export.ParentInstancedFullPath);
+            Assert.IsTrue(export.ObjectFlags.HasFlag(UnrealFlags.EObjectFlags.Public));
+            Assert.IsTrue(export.ObjectFlags.HasFlag(UnrealFlags.EObjectFlags.Standalone));
+            Assert.IsTrue(export.ObjectFlags.HasFlag(UnrealFlags.EObjectFlags.LoadForClient));
+            Assert.IsTrue(export.ObjectFlags.HasFlag(UnrealFlags.EObjectFlags.LoadForServer));
+            Assert.IsTrue(export.ObjectFlags.HasFlag(UnrealFlags.EObjectFlags.LoadForEdit));
+            Assert.IsFalse(export.ObjectFlags.HasFlag(UnrealFlags.EObjectFlags.LocalizedResource));
+            Assert.IsTrue(export.ExportFlags.HasFlag(UnrealFlags.EExportFlags.ForcedExport));
             var binary = export.GetBinaryData<BioSoundNodeWaveStreamingData>();
             Assert.AreEqual(2, binary.BankPair.ICBBank.BankChunks.OfType<ISACTListBankChunk>()
                 .Count(chunk => chunk.ObjectType == "snde"));
@@ -264,6 +304,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies localized sample-bank names do not alter the content-bank filename or title.
+    /// </summary>
     [TestMethod]
     public void SourceBanks_CanUseLocalizedSampleBankName()
     {
@@ -287,6 +330,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies LE1 localization naming is applied to the streaming root and data export.
+    /// </summary>
     [TestMethod]
     public void CreateStreamingDataExport_AppliesLocalizedObjectNames()
     {
@@ -299,7 +345,7 @@ public class ISACTBankBuilderTests
             using IMEPackage package = MEPackageHandler.CreateMemoryEmptyPackage("LOC_DE.pcc", MEGame.LE1);
 
             ExportEntry export = ISACTHelper.CreateSoundNodeWaveStreamingData(
-                package, "native_bank", source.ICBPath, source.ISBPath, "_DE");
+                package, "native_bank", source.ICBPath, source.ISBPath, MELocalization.DEU);
 
             Assert.AreEqual("native_bank_DE", export.ObjectName.Name);
             Assert.AreEqual("DVDStreamingAudioData_DE.PC", export.ParentInstancedFullPath);
@@ -310,6 +356,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies Codex and Soundset filenames produce their required Sound Event names.
+    /// </summary>
     [TestMethod]
     public void NamedAuthoringModes_CreateExpectedEvents()
     {
@@ -346,6 +395,9 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Verifies looping music authoring creates one queue containing every generated Sound Event.
+    /// </summary>
     [TestMethod]
     public void MusicAuthoring_CreatesLoopingSoundQueue()
     {
@@ -382,9 +434,15 @@ public class ISACTBankBuilderTests
         }
     }
 
+    /// <summary>
+    /// Reads the first sample-buffer reference from a serialized Sound Event.
+    /// </summary>
     private static uint GetTrackBufferIndex(ISACTListBankChunk soundEvent) =>
         ((SoundEventSoundTracks)soundEvent.GetChunk(SoundEventSoundTracks.FixedChunkTitle)).SoundTracks.Single().BufferIndex;
 
+    /// <summary>
+    /// Serializes an ISACT bank for binary equality checks and reparsing.
+    /// </summary>
     private static byte[] Serialize(ISACTBank bank)
     {
         using var stream = new MemoryStream();
@@ -392,6 +450,9 @@ public class ISACTBankBuilderTests
         return stream.ToArray();
     }
 
+    /// <summary>
+    /// Round-trips a bank pair through its binary representation.
+    /// </summary>
     private static ISACTBankPair ReparsePair(ISACTBankPair pair)
     {
         using var icbStream = new MemoryStream(Serialize(pair.ICBBank));
@@ -399,6 +460,9 @@ public class ISACTBankBuilderTests
         return new ISACTBankPair { ICBBank = new ISACTBank(icbStream), ISBBank = new ISACTBank(isbStream) };
     }
 
+    /// <summary>
+    /// Creates an isolated directory for one test's bank and WAV files.
+    /// </summary>
     private static string CreateTempDirectory()
     {
         string path = Path.Combine(Path.GetTempPath(), $"LEX_ISACTBankBuilder_{Guid.NewGuid():N}");
@@ -406,6 +470,9 @@ public class ISACTBankBuilderTests
         return path;
     }
 
+    /// <summary>
+    /// Writes a deterministic mono PCM16 WAV fixture without relying on external audio files.
+    /// </summary>
     private static void WritePcmWave(string path, int frameCount)
     {
         const ushort channels = 1;

--- a/LegendaryExplorer/LegendaryExplorer.Tests/Audio/ISACTBankBuilderTests.cs
+++ b/LegendaryExplorer/LegendaryExplorer.Tests/Audio/ISACTBankBuilderTests.cs
@@ -1,0 +1,434 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using LegendaryExplorerCore;
+using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Sound.ISACT;
+using LegendaryExplorerCore.Unreal.BinaryConverters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LegendaryExplorer.Tests.Audio;
+
+[TestClass]
+public class ISACTBankBuilderTests
+{
+    [ClassInitialize]
+    public static void Initialize(TestContext _) => LegendaryExplorerCoreLib.InitLib(TaskScheduler.Default);
+
+    [TestMethod]
+    public void CreateSourceBanks_BuildsExpectedSamplesAndEvents()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(directory, "EN_dialogue_example_00000100_M.wav"), 100);
+            WritePcmWave(Path.Combine(directory, "EN_dialogue_example_00000101_F.wav"), 120);
+            WritePcmWave(Path.Combine(directory, "EN_dialogue_example_00000101_M.wav"), 140);
+
+            var result = ISACTBankBuilder.CreateSourceBanksFromWavFolder(directory, "test_bank");
+
+            CollectionAssert.AreEqual(
+                new[] { "VO_100", "VO_100_M", "VO_101", "VO_101_M" },
+                result.EventMappings.Select(mapping => mapping.EventName).ToArray());
+            CollectionAssert.AreEqual(
+                new[] { 0, 0, 1, 2 },
+                result.EventMappings.Select(mapping => mapping.SampleIndex).ToArray());
+
+            using var icbStream = new MemoryStream();
+            result.Banks.ICBBank.Write(icbStream);
+            icbStream.Position = 0;
+            var icb = new ISACTBank(icbStream);
+
+            using var isbStream = new MemoryStream();
+            result.Banks.ISBBank.Write(isbStream);
+            isbStream.Position = 0;
+            var isb = new ISACTBank(isbStream);
+
+            var events = icb.BankChunks.OfType<ISACTListBankChunk>().Where(list => list.ObjectType == "snde").ToList();
+            var samples = isb.BankChunks.OfType<ISACTListBankChunk>().Where(list => list.ObjectType == "samp").ToList();
+            Assert.AreEqual(4, events.Count);
+            Assert.AreEqual(3, samples.Count);
+
+            var index = icb.BankChunks.OfType<ContentIndexBankChunk>().Single();
+            CollectionAssert.AreEqual(
+                new[] { "VO_100", "VO_100_M", "VO_101", "VO_101_M" },
+                index.IndexPages.SelectMany(page => page.IndexEntries).Select(entry => entry.Title).ToArray());
+
+            CollectionAssert.AreEqual(
+                new uint[] { 0x10000, 0x10000, 0x10001, 0x10002 },
+                events.Select(GetTrackBufferIndex).ToArray());
+            Assert.AreEqual(2500, isb.BankChunks.OfType<IntBankChunk>().Single(chunk => chunk.ChunkName == "stri").Value);
+            Assert.IsTrue(samples.All(sample => sample.SampleData?.Length > 0));
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [TestMethod]
+    public void CreateSourceBanks_IsDeterministicAndUsesSingleGenderAsSharedFallback()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(directory, "VO_200_M.wav"), 100);
+            WritePcmWave(Path.Combine(directory, "VO_199_F.wav"), 100);
+
+            var first = ISACTBankBuilder.CreateSourceBanksFromWavFolder(directory, "deterministic");
+            var second = ISACTBankBuilder.CreateSourceBanksFromWavFolder(directory, "deterministic");
+
+            CollectionAssert.AreEqual(new[] { 0, 0, 1, 1 }, first.EventMappings.Select(mapping => mapping.SampleIndex).ToArray());
+            CollectionAssert.AreEqual(Serialize(first.Banks.ICBBank), Serialize(second.Banks.ICBBank));
+            CollectionAssert.AreEqual(Serialize(first.Banks.ISBBank), Serialize(second.Banks.ISBBank));
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [TestMethod]
+    public void CreateSourceBanks_RejectsMalformedConversationName()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(directory, "EN_line_without_a_string_ref.wav"), 100);
+
+            Assert.ThrowsExactly<InvalidDataException>(() =>
+                ISACTBankBuilder.CreateSourceBanksFromWavFolder(directory, "invalid"));
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [TestMethod]
+    public void CreateSourceBanks_SplitsContentIndexAtLegacyFiftyEntryLimit()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            for (int line = 0; line < 26; line++)
+                WritePcmWave(Path.Combine(directory, $"VO_{1000 + line}_M.wav"), 10);
+
+            var result = ISACTBankBuilder.CreateSourceBanksFromWavFolder(directory, "paged_bank");
+            var index = result.Banks.ICBBank.BankChunks.OfType<ContentIndexBankChunk>().Single();
+
+            CollectionAssert.AreEqual(
+                new[] { 50, 2 },
+                index.IndexPages.Select(page => page.IndexEntries.Length).ToArray());
+            Assert.AreEqual(52, result.EventMappings.Count);
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [TestMethod]
+    public void AppendCompiledBanks_PreservesExistingSamplesAndRebasesAddedObjects()
+    {
+        string existingDirectory = CreateTempDirectory();
+        string additionDirectory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(existingDirectory, "VO_100_M.wav"), 100);
+            WritePcmWave(Path.Combine(additionDirectory, "VO_200_F.wav"), 120);
+            WritePcmWave(Path.Combine(additionDirectory, "VO_200_M.wav"), 140);
+
+            var existing = ReparsePair(ISACTBankBuilder.CreateSourceBanksFromWavFolder(existingDirectory, "bank").Banks);
+            var additions = ReparsePair(ISACTBankBuilder.CreateSourceBanksFromWavFolder(additionDirectory, "bank").Banks);
+            byte[] originalSampleData = existing.ISBBank.BankChunks
+                .OfType<ISACTListBankChunk>().Single(chunk => chunk.ObjectType == "samp").SampleData.ToArray();
+
+            ISACTBankPair merged = ISACTBankBuilder.AppendCompiledBanks(existing, additions);
+            using var icbStream = new MemoryStream(Serialize(merged.ICBBank));
+            using var isbStream = new MemoryStream(Serialize(merged.ISBBank));
+            var reparsedIcb = new ISACTBank(icbStream);
+            var reparsedIsb = new ISACTBank(isbStream);
+            var events = reparsedIcb.BankChunks.OfType<ISACTListBankChunk>()
+                .Where(chunk => chunk.ObjectType == "snde").ToList();
+            var samples = reparsedIsb.BankChunks.OfType<ISACTListBankChunk>()
+                .Where(chunk => chunk.ObjectType == "samp").ToList();
+
+            Assert.AreEqual(4, events.Count);
+            Assert.AreEqual(3, samples.Count);
+            CollectionAssert.AreEqual(originalSampleData, samples[0].SampleData);
+            CollectionAssert.AreEqual(
+                new uint[] { 0x10000, 0x10000, 0x10001, 0x10002 },
+                events.Select(GetTrackBufferIndex).ToArray());
+            CollectionAssert.AreEqual(
+                new[] { "VO_100", "VO_100_M", "VO_200", "VO_200_M" },
+                reparsedIcb.BankChunks.OfType<ContentIndexBankChunk>().Single().IndexPages
+                    .SelectMany(page => page.IndexEntries).Select(entry => entry.Title).ToArray());
+        }
+        finally
+        {
+            Directory.Delete(existingDirectory, true);
+            Directory.Delete(additionDirectory, true);
+        }
+    }
+
+    [TestMethod]
+    public void AppendCompiledBanks_RejectsDuplicateEvents()
+    {
+        string firstDirectory = CreateTempDirectory();
+        string secondDirectory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(firstDirectory, "VO_100_M.wav"), 100);
+            WritePcmWave(Path.Combine(secondDirectory, "VO_100_M.wav"), 120);
+            var existing = ReparsePair(ISACTBankBuilder.CreateSourceBanksFromWavFolder(firstDirectory, "bank").Banks);
+            var additions = ReparsePair(ISACTBankBuilder.CreateSourceBanksFromWavFolder(secondDirectory, "bank").Banks);
+
+            Assert.ThrowsExactly<InvalidDataException>(() =>
+                ISACTBankBuilder.AppendCompiledBanks(existing, additions));
+        }
+        finally
+        {
+            Directory.Delete(firstDirectory, true);
+            Directory.Delete(secondDirectory, true);
+        }
+    }
+
+    [TestMethod]
+    public void ReplaceCompiledSample_PreservesIndexTitleAndOtherSamplePayloads()
+    {
+        string existingDirectory = CreateTempDirectory();
+        string replacementDirectory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(existingDirectory, "VO_100_F.wav"), 100);
+            WritePcmWave(Path.Combine(existingDirectory, "VO_100_M.wav"), 120);
+            WritePcmWave(Path.Combine(replacementDirectory, "VO_200_M.wav"), 180);
+            ISACTBankPair existing = ReparsePair(
+                ISACTBankBuilder.CreateSourceBanksFromWavFolder(existingDirectory, "bank").Banks);
+            ISACTBankPair replacement = ReparsePair(
+                ISACTBankBuilder.CreateSourceBanksFromWavFolder(replacementDirectory, "replacement").Banks);
+            var originalSamples = existing.ISBBank.BankChunks.OfType<ISACTListBankChunk>()
+                .Where(chunk => chunk.ObjectType == "samp").ToList();
+            byte[] untouchedData = originalSamples[0].SampleData.ToArray();
+            string replacedTitle = originalSamples[1].TitleInfo.Value;
+            ISACTListBankChunk compiledReplacement = replacement.ISBBank.BankChunks
+                .OfType<ISACTListBankChunk>().Single(chunk => chunk.ObjectType == "samp");
+
+            ISACTBankBuilder.ReplaceCompiledSample(existing.ISBBank, 1, compiledReplacement);
+            using var stream = new MemoryStream(Serialize(existing.ISBBank));
+            var reparsed = new ISACTBank(stream);
+            var samples = reparsed.BankChunks.OfType<ISACTListBankChunk>()
+                .Where(chunk => chunk.ObjectType == "samp").ToList();
+
+            CollectionAssert.AreEqual(untouchedData, samples[0].SampleData);
+            Assert.AreEqual(replacedTitle, samples[1].TitleInfo.Value);
+            Assert.AreEqual(1, ((IntBankChunk)samples[1].GetChunk("indx")).Value);
+            CollectionAssert.AreEqual(compiledReplacement.SampleData, samples[1].SampleData);
+        }
+        finally
+        {
+            Directory.Delete(existingDirectory, true);
+            Directory.Delete(replacementDirectory, true);
+        }
+    }
+
+    [TestMethod]
+    public void CreateStreamingDataExport_CreatesExportInEmptyPackage()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(directory, "VO_100_M.wav"), 100);
+            var source = ISACTBankBuilder.WriteSourceBanksFromWavFolder(directory, directory, "native_bank");
+            using IMEPackage package = MEPackageHandler.CreateMemoryEmptyPackage("LOC_INT.pcc", MEGame.LE1);
+
+            ExportEntry export = ISACTHelper.CreateSoundNodeWaveStreamingData(
+                package, "native_bank", source.ICBPath, source.ISBPath);
+
+            Assert.AreEqual("BioSoundNodeWaveStreamingData", export.ClassName);
+            Assert.AreEqual("native_bank", export.ObjectName.Name);
+            Assert.AreEqual("DVDStreamingAudioData.PC", export.ParentInstancedFullPath);
+            var binary = export.GetBinaryData<BioSoundNodeWaveStreamingData>();
+            Assert.AreEqual(2, binary.BankPair.ICBBank.BankChunks.OfType<ISACTListBankChunk>()
+                .Count(chunk => chunk.ObjectType == "snde"));
+            Assert.AreEqual(1, binary.BankPair.ISBBank.BankChunks.OfType<ISACTListBankChunk>()
+                .Count(chunk => chunk.ObjectType == "samp"));
+            Assert.IsNull(binary.BankPair.ISBBank.BankChunks.OfType<ISACTListBankChunk>()
+                .Single(chunk => chunk.ObjectType == "samp").SampleData);
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [TestMethod]
+    public void SourceBanks_CanUseLocalizedSampleBankName()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(directory, "VO_100_M.wav"), 100);
+            var source = ISACTBankBuilder.WriteSourceBanksFromWavFolder(
+                directory, directory, "native_bank", sampleBankName: "native_bank_DE");
+
+            Assert.AreEqual("native_bank.icb", Path.GetFileName(source.ICBPath));
+            Assert.AreEqual("native_bank_DE.isb", Path.GetFileName(source.ISBPath));
+            using var icbStream = File.OpenRead(source.ICBPath);
+            using var isbStream = File.OpenRead(source.ISBPath);
+            Assert.AreEqual("native_bank.icb", new ISACTBank(icbStream).BankChunks.OfType<TitleBankChunk>().Single().Value);
+            Assert.AreEqual("native_bank_DE.isb", new ISACTBank(isbStream).BankChunks.OfType<TitleBankChunk>().Single().Value);
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [TestMethod]
+    public void CreateStreamingDataExport_AppliesLocalizedObjectNames()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(directory, "VO_100_M.wav"), 100);
+            var source = ISACTBankBuilder.WriteSourceBanksFromWavFolder(
+                directory, directory, "native_bank", sampleBankName: "native_bank_DE");
+            using IMEPackage package = MEPackageHandler.CreateMemoryEmptyPackage("LOC_DE.pcc", MEGame.LE1);
+
+            ExportEntry export = ISACTHelper.CreateSoundNodeWaveStreamingData(
+                package, "native_bank", source.ICBPath, source.ISBPath, "_DE");
+
+            Assert.AreEqual("native_bank_DE", export.ObjectName.Name);
+            Assert.AreEqual("DVDStreamingAudioData_DE.PC", export.ParentInstancedFullPath);
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [TestMethod]
+    public void NamedAuthoringModes_CreateExpectedEvents()
+    {
+        string codexDirectory = CreateTempDirectory();
+        string soundsetDirectory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(codexDirectory, "vo_codex_example_entry.wav"), 100);
+            WritePcmWave(Path.Combine(soundsetDirectory, "EN_example_atg00.wav"), 100);
+            WritePcmWave(Path.Combine(soundsetDirectory, "EN_example_png03.wav"), 100);
+            WritePcmWave(Path.Combine(soundsetDirectory, "EN_example_sb100.wav"), 100);
+            WritePcmWave(Path.Combine(soundsetDirectory, "EN_example_sb200.wav"), 100);
+
+            var codex = ISACTBankBuilder.CreateSourceBanksFromWavFolder(
+                codexDirectory, "codex", authoringMode: ISACTBankBuilder.AuthoringMode.Codex);
+            var soundset = ISACTBankBuilder.CreateSourceBanksFromWavFolder(
+                soundsetDirectory, "soundset", authoringMode: ISACTBankBuilder.AuthoringMode.Soundset);
+
+            CollectionAssert.AreEqual(
+                new[] { "vo_codex_example_entry" },
+                codex.EventMappings.Select(mapping => mapping.EventName).ToArray());
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "VO_AttackGrunt_00", "VO_PainGrunt_03",
+                    "VO_SpecialAbilityRacial1_00", "VO_SpecialAbilityRacial2_00"
+                },
+                soundset.EventMappings.Select(mapping => mapping.EventName).ToArray());
+        }
+        finally
+        {
+            Directory.Delete(codexDirectory, true);
+            Directory.Delete(soundsetDirectory, true);
+        }
+    }
+
+    [TestMethod]
+    public void MusicAuthoring_CreatesLoopingSoundQueue()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            WritePcmWave(Path.Combine(directory, "music_example.wav"), 100);
+            var eventsOnly = ISACTBankBuilder.CreateSourceBanksFromWavFolder(
+                directory, "mus_example", 2000,
+                authoringMode: ISACTBankBuilder.AuthoringMode.Music);
+            var result = ISACTBankBuilder.CreateSourceBanksFromWavFolder(
+                directory, "mus_example", 2000,
+                authoringMode: ISACTBankBuilder.AuthoringMode.Music,
+                createLoopingMusicQueue: true);
+
+            Assert.IsFalse(eventsOnly.Banks.ICBBank.BankChunks.OfType<ISACTListBankChunk>()
+                .Any(chunk => chunk.ObjectType == "sdqu"));
+            ISACTListBankChunk queue = result.Banks.ICBBank.BankChunks.OfType<ISACTListBankChunk>()
+                .Single(chunk => chunk.ObjectType == "sdqu");
+            CollectionAssert.AreEqual(
+                new[] { "music_example", "mus_example" },
+                result.Banks.ICBBank.BankChunks.OfType<ContentIndexBankChunk>().Single().IndexPages
+                    .SelectMany(page => page.IndexEntries).Select(entry => entry.Title).ToArray());
+            CollectionAssert.AreEqual(
+                new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                queue.GetChunk("qinf").RawData);
+            CollectionAssert.AreEqual(
+                new byte[] { (byte)'s', (byte)'n', (byte)'d', (byte)'e', 0, 0, 0, 0 },
+                queue.GetChunk("qcnt").RawData);
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    private static uint GetTrackBufferIndex(ISACTListBankChunk soundEvent) =>
+        ((SoundEventSoundTracks)soundEvent.GetChunk(SoundEventSoundTracks.FixedChunkTitle)).SoundTracks.Single().BufferIndex;
+
+    private static byte[] Serialize(ISACTBank bank)
+    {
+        using var stream = new MemoryStream();
+        bank.Write(stream);
+        return stream.ToArray();
+    }
+
+    private static ISACTBankPair ReparsePair(ISACTBankPair pair)
+    {
+        using var icbStream = new MemoryStream(Serialize(pair.ICBBank));
+        using var isbStream = new MemoryStream(Serialize(pair.ISBBank));
+        return new ISACTBankPair { ICBBank = new ISACTBank(icbStream), ISBBank = new ISACTBank(isbStream) };
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"LEX_ISACTBankBuilder_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void WritePcmWave(string path, int frameCount)
+    {
+        const ushort channels = 1;
+        const ushort bitsPerSample = 16;
+        const uint sampleRate = 44100;
+        const ushort blockAlign = channels * (bitsPerSample / 8);
+        byte[] pcm = new byte[frameCount * blockAlign];
+
+        using var stream = File.Create(path);
+        using var writer = new BinaryWriter(stream);
+        writer.Write("RIFF"u8);
+        writer.Write(36 + pcm.Length);
+        writer.Write("WAVE"u8);
+        writer.Write("fmt "u8);
+        writer.Write(16);
+        writer.Write((ushort)1);
+        writer.Write(channels);
+        writer.Write(sampleRate);
+        writer.Write(sampleRate * blockAlign);
+        writer.Write(blockAlign);
+        writer.Write(bitsPerSample);
+        writer.Write("data"u8);
+        writer.Write(pcm.Length);
+        writer.Write(pcm);
+    }
+}

--- a/LegendaryExplorer/LegendaryExplorer.Tests/Audio/ISACTBankBuilderTests.cs
+++ b/LegendaryExplorer/LegendaryExplorer.Tests/Audio/ISACTBankBuilderTests.cs
@@ -357,7 +357,7 @@ public class ISACTBankBuilderTests
     }
 
     /// <summary>
-    /// Verifies Codex and Soundset filenames produce their required Sound Event names.
+    /// Verifies Codex locale prefixes and Soundset suffixes produce their required Sound Event names.
     /// </summary>
     [TestMethod]
     public void NamedAuthoringModes_CreateExpectedEvents()
@@ -367,6 +367,7 @@ public class ISACTBankBuilderTests
         try
         {
             WritePcmWave(Path.Combine(codexDirectory, "vo_codex_example_entry.wav"), 100);
+            WritePcmWave(Path.Combine(codexDirectory, "EN_vo_codex_localized_entry.wav"), 100);
             WritePcmWave(Path.Combine(soundsetDirectory, "EN_example_atg00.wav"), 100);
             WritePcmWave(Path.Combine(soundsetDirectory, "EN_example_png03.wav"), 100);
             WritePcmWave(Path.Combine(soundsetDirectory, "EN_example_sb100.wav"), 100);
@@ -378,7 +379,7 @@ public class ISACTBankBuilderTests
                 soundsetDirectory, "soundset", authoringMode: ISACTBankBuilder.AuthoringMode.Soundset);
 
             CollectionAssert.AreEqual(
-                new[] { "vo_codex_example_entry" },
+                new[] { "vo_codex_localized_entry", "vo_codex_example_entry" },
                 codex.EventMappings.Select(mapping => mapping.EventName).ToArray());
             CollectionAssert.AreEqual(
                 new[]

--- a/LegendaryExplorer/LegendaryExplorer/Dialogs/ISACTBankBuilderDialog.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/Dialogs/ISACTBankBuilderDialog.xaml
@@ -1,0 +1,124 @@
+<misc:NotifyPropertyChangedWindowBase x:Class="LegendaryExplorer.Dialogs.ISACTBankBuilderDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:misc="clr-namespace:LegendaryExplorer.Misc"
+        Title="ISACT Bank Builder" Width="760" SizeToContent="Height"
+        MaxHeight="850" WindowStartupLocation="CenterOwner" ResizeMode="CanResizeWithGrip">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid Margin="12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="165"/><ColumnDefinition Width="*"/><ColumnDefinition Width="80"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <StackPanel Grid.ColumnSpan="3" Margin="0,0,0,10">
+                <TextBlock x:Name="DescriptionText" TextWrapping="Wrap"/>
+                <TextBlock Margin="0,4,0,0">
+                    <Hyperlink NavigateUri="https://github.com/ME3Tweaks/LegendaryExplorer/wiki/Audio-Authoring-with-ISACT-in-LE1"
+                               misc:HyperlinkExtensions.IsExternal="True">View ISACT authoring documentation</Hyperlink>
+                </TextBlock>
+            </StackPanel>
+
+            <Label Grid.Row="1" Content="WAV source folder:" ToolTip="Folder containing the source WAVs."/>
+            <TextBox x:Name="WavFolderBox" Grid.Row="1" Grid.Column="1" Margin="3"
+                     ToolTip="WAV naming depends on the selected content type."/>
+            <Button Grid.Row="1" Grid.Column="2" Margin="3" Content="Browse" Click="BrowseWavFolder_Click"
+                    ToolTip="Select the folder containing the source WAVs."/>
+
+            <StackPanel Grid.Row="2" Grid.ColumnSpan="3">
+                <Grid x:Name="ExistingBankPanel">
+                    <Grid.ColumnDefinitions><ColumnDefinition Width="165"/><ColumnDefinition Width="*"/><ColumnDefinition Width="80"/></Grid.ColumnDefinitions>
+                    <Label Content="Existing ISB:" ToolTip="The final sample bank that new or replacement audio will be added to."/>
+                    <TextBox x:Name="ExistingIsbBox" Grid.Column="1" Margin="3" ToolTip="Existing compiled ISACT sample bank."/>
+                    <Button Grid.Column="2" Margin="3" Content="Browse" Click="BrowseExistingIsb_Click" ToolTip="Select the existing ISB."/>
+                </Grid>
+                <Grid>
+                    <Grid.ColumnDefinitions><ColumnDefinition Width="165"/><ColumnDefinition Width="*"/><ColumnDefinition Width="80"/></Grid.ColumnDefinitions>
+                    <Label Content="Content type:" ToolTip="Controls how WAV filenames become Sound Events."/>
+                    <ComboBox x:Name="AuthoringModeComboBox" Grid.Column="1" Grid.ColumnSpan="2" Margin="3"
+                              DisplayMemberPath="DisplayName" SelectionChanged="AuthoringModeComboBox_SelectionChanged"
+                              ToolTip="Conversation pairs VO line IDs; codex uses exact names; soundsets translate vanilla cue codes; music uses named events."/>
+                </Grid>
+                <CheckBox x:Name="LoopingMusicQueueCheckBox" Margin="168,3,3,3" Visibility="Collapsed"
+                          Content="Create a looping Sound Queue named after the bank"
+                          ToolTip="Optional. Without this, music WAVs create ordinary Sound Events only."/>
+            </StackPanel>
+
+            <Label Grid.Row="3" Content="Bank name:" ToolTip="Name used for the generated ICB and ISB."/>
+            <Grid Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/><ColumnDefinition Width="95"/><ColumnDefinition Width="85"/>
+                </Grid.ColumnDefinitions>
+                <TextBox x:Name="BankNameBox" Margin="3" ToolTip="For conversations, this should normally match the BioConversation name."/>
+                <Label Grid.Column="1" Content="Localisation:" ToolTip="Language suffix used by LE1 audio objects."/>
+                <ComboBox x:Name="LocalizationComboBox" Grid.Column="2" Margin="3" DisplayMemberPath="DisplayName"
+                          ToolTip="Controls the ISB, BioStreamingData and DVDStreamingAudioData suffix. Inferred from a selected LOC package."/>
+            </Grid>
+
+            <Label Grid.Row="4" Content="Output folder:" ToolTip="Folder where the final banks will be written."/>
+            <TextBox x:Name="OutputFolderBox" Grid.Row="4" Grid.Column="1" Margin="3" ToolTip="Output location for the compiled ICB and ISB."/>
+            <Button Grid.Row="4" Grid.Column="2" Margin="3" Content="Browse" Click="BrowseOutputFolder_Click" ToolTip="Select the output folder."/>
+
+            <Label Grid.Row="5" Content="BankBuilder.exe:" ToolTip="Official ISACT command-line bank compiler."/>
+            <TextBox x:Name="BankBuilderBox" Grid.Row="5" Grid.Column="1" Margin="3" ToolTip="Path to the official BankBuilder.exe."/>
+            <Button Grid.Row="5" Grid.Column="2" Margin="3" Content="Browse" Click="BrowseBankBuilder_Click" ToolTip="Locate BankBuilder.exe."/>
+
+            <Label Grid.Row="6" Content="Stream packet (ms):" ToolTip="Streaming packet duration stored in the sample bank."/>
+            <TextBox x:Name="PacketSizeBox" Grid.Row="6" Grid.Column="1" Width="100" HorizontalAlignment="Left" Margin="3" Text="2500"
+                     ToolTip="LE1 dialogue banks commonly use 2500 ms."/>
+            <Label Grid.Row="7" Content="Vorbis quality:" ToolTip="Ogg Vorbis compression quality passed to BankBuilder."/>
+            <TextBox x:Name="QualityBox" Grid.Row="7" Grid.Column="1" Width="100" HorizontalAlignment="Left" Margin="3" Text="0.8"
+                     ToolTip="Compression quality from 0 to 1. LE1 commonly uses 0.8."/>
+
+            <CheckBox x:Name="NormalizeCheckBox" Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="2" Margin="3,8" IsChecked="True"
+                      Content="Convert incompatible WAVs to signed 16-bit PCM automatically"
+                      ToolTip="Converts unsupported WAV formats while preserving sample rate and channel count."/>
+
+            <Separator Grid.Row="9" Grid.ColumnSpan="3" Margin="0,8"/>
+            <CheckBox x:Name="CopyIsbCheckBox" Grid.Row="10" Grid.ColumnSpan="3" Margin="3"
+                      Content="Copy the finished ISB into a DLC Content folder"
+                      ToolTip="Copies the external sample bank into the selected mod Content folder."/>
+            <Label Grid.Row="11" Content="DLC Content folder:" ToolTip="Usually DLC_MOD_Name/Content."/>
+            <TextBox x:Name="DlcContentBox" Grid.Row="11" Grid.Column="1" Margin="3" ToolTip="Destination folder for the external ISB."/>
+            <Button Grid.Row="11" Grid.Column="2" Margin="3" Content="Browse" Click="BrowseDlcContent_Click" ToolTip="Select the DLC Content folder."/>
+
+            <Separator Grid.Row="12" Grid.ColumnSpan="3" Margin="0,8"/>
+            <CheckBox x:Name="PackageIntegrationCheckBox" Grid.Row="13" Grid.ColumnSpan="3" Margin="3" IsChecked="True"
+                      Content="Create or update BioSoundNodeWaveStreamingData in a package"
+                      ToolTip="Writes the compiled ICB and stripped ISB metadata into the selected package export."/>
+            <Label Grid.Row="14" Content="Package file:" ToolTip="LE1 package containing the target streaming-data export."/>
+            <TextBox x:Name="DestinationPccBox" Grid.Row="14" Grid.Column="1" Margin="3" ToolTip="Package that will receive the new or rebuilt bank metadata."/>
+            <Button Grid.Row="14" Grid.Column="2" Margin="3" Content="Browse" Click="BrowseDestinationPcc_Click" ToolTip="Select an LE1 PCC or UPK."/>
+            <Label Grid.Row="15" Content="BioStreamingData export:" ToolTip="Streaming-data export to update."/>
+            <ComboBox x:Name="StreamingDataComboBox" Grid.Row="15" Grid.Column="1" Grid.ColumnSpan="2" Margin="3"
+                      DisplayMemberPath="DisplayName" SelectedValuePath="UIndex"
+                      ToolTip="Choose existing BioStreamingData. New builds can instead create one."/>
+
+            <StackPanel x:Name="ExistingIcbPanel" Grid.Row="16" Grid.ColumnSpan="3">
+                <Grid>
+                    <Grid.ColumnDefinitions><ColumnDefinition Width="165"/><ColumnDefinition Width="*"/><ColumnDefinition Width="80"/></Grid.ColumnDefinitions>
+                    <Label Content="Existing ICB (optional):" ToolTip="Optional override for the ICB embedded in the selected BioStreamingData."/>
+                    <TextBox x:Name="ExistingIcbBox" Grid.Column="1" Margin="3"
+                             ToolTip="Leave blank to extract the current ICB from the selected package export."/>
+                    <Button Grid.Column="2" Margin="3" Content="Browse" Click="BrowseExistingIcb_Click" ToolTip="Select an external existing ICB."/>
+                </Grid>
+            </StackPanel>
+
+            <Separator Grid.Row="17" Grid.ColumnSpan="3" Margin="0,8"/>
+            <TextBlock x:Name="StatusText" Grid.Row="18" Grid.ColumnSpan="3" Margin="3" TextWrapping="Wrap"/>
+            <ProgressBar x:Name="Progress" Grid.Row="19" Grid.ColumnSpan="3" Height="16" Margin="3" IsIndeterminate="True" Visibility="Collapsed"/>
+            <StackPanel Grid.Row="20" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                <Button Width="90" Margin="3" Content="Cancel" Click="Cancel_Click" ToolTip="Close without running the operation."/>
+                <Button x:Name="RunButton" Width="110" Margin="3" Content="Build" IsDefault="True" Click="Run_Click" ToolTip="Run the configured ISACT bank operation."/>
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
+</misc:NotifyPropertyChangedWindowBase>

--- a/LegendaryExplorer/LegendaryExplorer/Dialogs/ISACTBankBuilderDialog.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Dialogs/ISACTBankBuilderDialog.xaml.cs
@@ -15,24 +15,45 @@ using NAudio.Wave;
 
 namespace LegendaryExplorer.Dialogs;
 
+/// <summary>
+/// Selects whether the dialog creates a bank pair or appends to an existing pair.
+/// </summary>
 public enum ISACTBankBuildMode
 {
+    /// <summary>Create a new ICB and ISB from source WAV files.</summary>
     Build,
+    /// <summary>Append newly compiled content to an existing ICB and ISB.</summary>
     Rebuild
 }
 
+/// <summary>
+/// Coordinates WAV preparation, ISACT bank compilation, and optional LE1 package installation.
+/// </summary>
 public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
 {
+    /// <summary>Identifies a BioSoundNodeWaveStreamingData export displayed in the package selector.</summary>
     private sealed record StreamingDataChoice(int UIndex, string DisplayName);
-    private sealed record LocalizationChoice(string Suffix, string DisplayName);
+
+    /// <summary>Pairs an LE localization with the suffix used by LE1 ISACT object and bank names.</summary>
+    private sealed record LocalizationChoice(MELocalization Localization, string DisplayName)
+    {
+        public string Suffix => Localization is MELocalization.None or MELocalization.INT
+            ? string.Empty
+            : $"_{Localization.ToLocaleString(MEGame.LE1)}";
+    }
+
+    /// <summary>Defines filename interpretation and user guidance for an authoring mode.</summary>
     private sealed record AuthoringModeChoice(
         ISACTBankBuilder.AuthoringMode Mode, string DisplayName, string WavTooltip);
 
+    // ES and JA use INT audio in LE1 and therefore have no separate ISACT authoring target.
     private static readonly LocalizationChoice[] Localizations =
     [
-        new("", "INT"), new("_DE", "DE"), new("_FR", "FR"),
-        new("_IT", "IT"), new("_PLPC", "PLPC"), new("_RA", "RA")
+        new(MELocalization.INT, "INT"), new(MELocalization.DEU, "DE"),
+        new(MELocalization.FRA, "FR"), new(MELocalization.ITA, "IT"),
+        new(MELocalization.POL, "PLPC"), new(MELocalization.RUS, "RA")
     ];
+    // Each mode applies a different WAV filename-to-Sound Event naming rule.
     private static readonly AuthoringModeChoice[] AuthoringModes =
     [
         new(ISACTBankBuilder.AuthoringMode.Conversation, "BioConversation",
@@ -47,6 +68,11 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
 
     private readonly ISACTBankBuildMode _mode;
 
+    /// <summary>
+    /// Creates a bank-authoring dialog configured for a new build or an append operation.
+    /// </summary>
+    /// <param name="mode">Operation exposed by the dialog.</param>
+    /// <param name="owner">Window that owns this dialog.</param>
     public ISACTBankBuilderDialog(ISACTBankBuildMode mode, Window owner)
     {
         _mode = mode;
@@ -62,6 +88,7 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
             "ISACT", "ISACT SDK", "Win", "Bin", "BankBuilder.exe");
         if (File.Exists(defaultBuilder)) BankBuilderBox.Text = defaultBuilder;
 
+        // Build and rebuild share the form; only rebuild exposes existing-bank inputs.
         bool rebuild = mode == ISACTBankBuildMode.Rebuild;
         ExistingBankPanel.Visibility = rebuild ? Visibility.Visible : Visibility.Collapsed;
         ExistingIcbPanel.Visibility = rebuild ? Visibility.Visible : Visibility.Collapsed;
@@ -74,6 +101,9 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         SetStreamingDataChoices([]);
     }
 
+    /// <summary>
+    /// Selects source WAVs and derives default output and bank names from their folder.
+    /// </summary>
     private void BrowseWavFolder_Click(object sender, RoutedEventArgs e)
     {
         string path = SelectFolder("Select the folder containing source WAV files");
@@ -84,12 +114,19 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
             BankNameBox.Text = new DirectoryInfo(path).Name;
     }
 
+    /// <summary>Selects the directory that receives the final ICB and ISB.</summary>
     private void BrowseOutputFolder_Click(object sender, RoutedEventArgs e) => SetFolder(OutputFolderBox, "Select the output folder");
+
+    /// <summary>Selects the DLC Content directory that receives an optional ISB copy.</summary>
     private void BrowseDlcContent_Click(object sender, RoutedEventArgs e) => SetFolder(DlcContentBox, "Select DLC_MOD_Example/Content");
 
+    /// <summary>Selects the optional content bank used by a rebuild.</summary>
     private void BrowseExistingIcb_Click(object sender, RoutedEventArgs e) =>
         SetFile(ExistingIcbBox, "ISACT Content Bank (*.icb)|*.icb", "Select the existing ICB");
 
+    /// <summary>
+    /// Selects the sample bank used by a rebuild and derives its bank name and localization.
+    /// </summary>
     private void BrowseExistingIsb_Click(object sender, RoutedEventArgs e)
     {
         string path = SelectFile("ISACT Sample Bank (*.isb)|*.isb", "Select the existing ISB");
@@ -111,9 +148,13 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         if (string.IsNullOrWhiteSpace(OutputFolderBox.Text)) OutputFolderBox.Text = Path.GetDirectoryName(path);
     }
 
+    /// <summary>Selects the external ISACT BankBuilder executable.</summary>
     private void BrowseBankBuilder_Click(object sender, RoutedEventArgs e) =>
         SetFile(BankBuilderBox, "BankBuilder.exe|BankBuilder.exe|Executable (*.exe)|*.exe", "Select BankBuilder.exe");
 
+    /// <summary>
+    /// Selects an LE1 package and loads its localization and streaming-data exports.
+    /// </summary>
     private void BrowseDestinationPcc_Click(object sender, RoutedEventArgs e)
     {
         string path = SelectFile("Unreal package (*.pcc;*.upk)|*.pcc;*.upk", "Select the destination LE1 package");
@@ -132,6 +173,9 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         }
     }
 
+    /// <summary>
+    /// Validates the form, prepares WAV input, builds or appends banks, and installs optional outputs.
+    /// </summary>
     private async void Run_Click(object sender, RoutedEventArgs e)
     {
         string normalizedFolder = null;
@@ -140,6 +184,7 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         {
             ValidateInputs();
             SetRunning(true, "Checking WAV input...");
+            // Conversion uses a temporary folder so the author's source WAVs remain unchanged.
             bool allowNormalisation = NormalizeCheckBox.IsChecked == true;
             normalizedFolder = await Task.Run(() => PrepareWavInput(WavFolderBox.Text, allowNormalisation));
 
@@ -149,12 +194,14 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
             string inputIcbPath = ExistingIcbBox.Text;
             if (_mode == ISACTBankBuildMode.Rebuild && string.IsNullOrWhiteSpace(inputIcbPath))
             {
+                // Rebuild can recover a discarded ICB from the selected package's stripped bank pair.
                 extractedIcbDirectory = Path.Combine(Path.GetTempPath(), $"LEX_ISACTEmbeddedICB_{Guid.NewGuid():N}");
                 Directory.CreateDirectory(extractedIcbDirectory);
                 inputIcbPath = Path.Combine(extractedIcbDirectory, $"{BankNameBox.Text}.icb");
                 ExtractEmbeddedIcb(DestinationPccBox.Text, selectedStreamingData, ExistingIsbBox.Text, inputIcbPath);
             }
 
+            // Only newly supplied WAVs reach BankBuilder during an append operation.
             SetRunning(true, _mode == ISACTBankBuildMode.Build
                 ? "Building ISACT banks..."
                 : "Compiling and appending new ISACT content...");
@@ -172,16 +219,18 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
 
             if (CopyIsbCheckBox.IsChecked == true)
             {
+                // ISBs are external runtime files and may be installed directly into DLC Content.
                 Directory.CreateDirectory(DlcContentBox.Text);
                 File.Copy(result.ISBPath, Path.Combine(DlcContentBox.Text, Path.GetFileName(result.ISBPath)), true);
             }
 
             if (PackageIntegrationCheckBox.IsChecked == true)
             {
+                // Existing exports retain their references; new exports are created in the LE1 streaming hierarchy.
                 SetRunning(true, "Updating BioSoundNodeWaveStreamingData...");
                 await Task.Run(() => InstallStreamingData(
                     DestinationPccBox.Text, selectedStreamingData, BankNameBox.Text,
-                    GetLocalizationSuffix(), result.ICBPath, result.ISBPath));
+                    GetLocalization(), result.ICBPath, result.ISBPath));
             }
 
             SetRunning(false, $"Created {result.EventMappings.Count} sound events.\n{result.ICBPath}\n{result.ISBPath}");
@@ -201,6 +250,9 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         }
     }
 
+    /// <summary>
+    /// Validates fields required by the selected operation and optional installation steps.
+    /// </summary>
     private void ValidateInputs()
     {
         if (!Directory.Exists(WavFolderBox.Text)) throw new DirectoryNotFoundException("Select a valid WAV source folder.");
@@ -218,11 +270,12 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         if (CopyIsbCheckBox.IsChecked == true && string.IsNullOrWhiteSpace(DlcContentBox.Text))
             throw new InvalidDataException("Select the DLC Content folder.");
 
+        // Rebuild without an external ICB must recover the embedded content bank from a package.
         bool packageNeeded = PackageIntegrationCheckBox.IsChecked == true ||
                              (_mode == ISACTBankBuildMode.Rebuild && string.IsNullOrWhiteSpace(ExistingIcbBox.Text));
         if (packageNeeded && !File.Exists(DestinationPccBox.Text))
             throw new FileNotFoundException("Select the package containing the target BioStreamingData.");
-        if (packageNeeded && GetPackageLocalizationSuffix(DestinationPccBox.Text) != GetLocalizationSuffix())
+        if (packageNeeded && GetPackageLocalization(DestinationPccBox.Text) != GetLocalization())
             throw new InvalidDataException(
                 "The selected localisation does not match the destination LOC package.");
         if (packageNeeded && _mode == ISACTBankBuildMode.Rebuild && GetSelectedStreamingDataIndex() <= 0)
@@ -231,6 +284,10 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
             throw new FileNotFoundException("The optional existing ICB could not be found.", ExistingIcbBox.Text);
     }
 
+    /// <summary>
+    /// Verifies WAV channel and sample formats and optionally creates temporary PCM16 copies.
+    /// </summary>
+    /// <returns>A temporary converted directory, or <see langword="null"/> when conversion is unnecessary.</returns>
     private static string PrepareWavInput(string sourceFolder, bool allowNormalisation)
     {
         string[] files = Directory.GetFiles(sourceFolder, "*.wav", SearchOption.TopDirectoryOnly);
@@ -248,6 +305,7 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         if (!allowNormalisation)
             throw new InvalidDataException("One or more WAV files are not signed 16-bit PCM. Enable automatic conversion or clean the sources first.");
 
+        // Converted copies preserve source filenames because event naming is filename-driven.
         string convertedFolder = Path.Combine(Path.GetTempPath(), $"LEX_ISACT_PCM16_{Guid.NewGuid():N}");
         Directory.CreateDirectory(convertedFolder);
         foreach (string file in files)
@@ -262,6 +320,9 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         return convertedFolder;
     }
 
+    /// <summary>
+    /// Loads available BioSoundNodeWaveStreamingData destinations from an LE1 package.
+    /// </summary>
     private void LoadStreamingDataChoices(string packagePath)
     {
         using IMEPackage package = MEPackageHandler.OpenMEPackage(packagePath, forceLoadFromDisk: true);
@@ -273,19 +334,29 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         SetStreamingDataChoices(choices);
     }
 
+    /// <summary>Selects the authoring localization inferred from the destination package name.</summary>
     private void SelectPackageLocalization(string packagePath)
     {
-        string suffix = GetPackageLocalizationSuffix(packagePath);
-        LocalizationComboBox.SelectedItem = Localizations.Single(choice => choice.Suffix == suffix);
+        MELocalization localization = GetPackageLocalization(packagePath);
+        LocalizationComboBox.SelectedItem = Localizations.Single(choice => choice.Localization == localization);
     }
 
+    /// <summary>Returns the localization selected for generated object and sample-bank names.</summary>
+    private MELocalization GetLocalization() =>
+        (LocalizationComboBox.SelectedItem as LocalizationChoice)?.Localization ?? MELocalization.INT;
+
+    /// <summary>Returns the LE1 suffix used by the selected audio localization.</summary>
     private string GetLocalizationSuffix() =>
         (LocalizationComboBox.SelectedItem as LocalizationChoice)?.Suffix ?? "";
 
+    /// <summary>Returns the filename interpretation selected for source WAVs.</summary>
     private ISACTBankBuilder.AuthoringMode GetAuthoringMode() =>
         (AuthoringModeComboBox.SelectedItem as AuthoringModeChoice)?.Mode
         ?? ISACTBankBuilder.AuthoringMode.Conversation;
 
+    /// <summary>
+    /// Updates filename guidance and music-specific options when the authoring mode changes.
+    /// </summary>
     private void AuthoringModeComboBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
     {
         if (WavFolderBox is null || AuthoringModeComboBox.SelectedItem is not AuthoringModeChoice choice) return;
@@ -295,26 +366,19 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
             : Visibility.Collapsed;
         if (choice.Mode != ISACTBankBuilder.AuthoringMode.Music)
             LoopingMusicQueueCheckBox.IsChecked = false;
+        // Shipped LE1 music commonly uses 2000 ms packets instead of the dialogue-oriented default.
         if (choice.Mode == ISACTBankBuilder.AuthoringMode.Music && PacketSizeBox?.Text == "2500")
             PacketSizeBox.Text = "2000";
     }
 
-    private static string GetPackageLocalizationSuffix(string packagePath)
+    /// <summary>Infers an LE localization from a package filename and treats unlocalized files as INT.</summary>
+    private static MELocalization GetPackageLocalization(string packagePath)
     {
         MELocalization localization = Path.GetFileNameWithoutExtension(packagePath).GetUnrealLocalization();
-        return localization switch
-        {
-            MELocalization.None or MELocalization.INT => "",
-            MELocalization.DEU => "_DE",
-            MELocalization.FRA => "_FR",
-            MELocalization.ITA => "_IT",
-            MELocalization.POL => "_PLPC",
-            MELocalization.RUS => "_RA",
-            _ => throw new InvalidDataException(
-                $"'{Path.GetFileName(packagePath)}' is not a supported LE1 LOC package name.")
-        };
+        return localization == MELocalization.None ? MELocalization.INT : localization;
     }
 
+    /// <summary>Builds a selector label from an export path and its embedded content-bank title.</summary>
     private static string DescribeStreamingData(ExportEntry export)
     {
         string bankTitle = null;
@@ -323,21 +387,27 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
             bankTitle = export.GetBinaryData<BioSoundNodeWaveStreamingData>().BankPair.ICBBank.BankChunks
                 .OfType<TitleBankChunk>().FirstOrDefault()?.Value;
         }
+        // Malformed exports remain selectable so validation can report the underlying bank error later.
         catch { }
         return bankTitle is null
             ? $"#{export.UIndex} {export.InstancedFullPath}"
             : $"#{export.UIndex} {export.InstancedFullPath} - {bankTitle}";
     }
 
+    /// <summary>Replaces and initializes the available streaming-data destinations.</summary>
     private void SetStreamingDataChoices(IReadOnlyCollection<StreamingDataChoice> choices)
     {
         StreamingDataComboBox.ItemsSource = choices;
         StreamingDataComboBox.SelectedIndex = choices.Count > 0 ? 0 : -1;
     }
 
+    /// <summary>Returns the selected streaming-data UIndex, or -1 when no destination is selected.</summary>
     private int GetSelectedStreamingDataIndex() =>
         StreamingDataComboBox.SelectedItem is StreamingDataChoice choice ? choice.UIndex : -1;
 
+    /// <summary>
+    /// Recovers an embedded ICB after confirming the selected external ISB belongs to the same bank pair.
+    /// </summary>
     private static void ExtractEmbeddedIcb(
         string packagePath, int streamingDataUIndex, string existingIsbPath, string outputPath)
     {
@@ -354,8 +424,11 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         ISACTHelper.ExportStreamingDataContentBank(streamingData, outputPath);
     }
 
+    /// <summary>
+    /// Updates a selected export or creates one under the localized DVDStreamingAudioData package.
+    /// </summary>
     private static void InstallStreamingData(
-        string destinationPath, int streamingDataUIndex, string bankName, string localizationSuffix,
+        string destinationPath, int streamingDataUIndex, string bankName, MELocalization localization,
         string icbPath, string isbPath)
     {
         using IMEPackage destination = MEPackageHandler.OpenMEPackage(destinationPath, forceLoadFromDisk: true);
@@ -367,10 +440,11 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
                 GetStreamingDataExport(destination, streamingDataUIndex), icbPath, isbPath);
         else
             ISACTHelper.CreateSoundNodeWaveStreamingData(
-                destination, bankName, icbPath, isbPath, localizationSuffix);
+                destination, bankName, icbPath, isbPath, localization);
         destination.Save();
     }
 
+    /// <summary>Resolves and validates a BioSoundNodeWaveStreamingData export by UIndex.</summary>
     private static ExportEntry GetStreamingDataExport(IMEPackage package, int uIndex)
     {
         if (!package.TryGetUExport(uIndex, out ExportEntry export) || export.ClassName != "BioSoundNodeWaveStreamingData")
@@ -378,6 +452,7 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         return export;
     }
 
+    /// <summary>Updates command availability, progress visibility, and operation status.</summary>
     private void SetRunning(bool running, string status)
     {
         RunButton.IsEnabled = !running;
@@ -385,32 +460,38 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         StatusText.Text = status;
     }
 
+    /// <summary>Closes the dialog.</summary>
     private void Cancel_Click(object sender, RoutedEventArgs e) => Close();
 
+    /// <summary>Displays an owned folder picker and returns the selected path.</summary>
     private string SelectFolder(string title)
     {
         var dialog = new CommonOpenFileDialog(title) { IsFolderPicker = true };
         return dialog.ShowDialog(this) == CommonFileDialogResult.Ok ? dialog.FileName : null;
     }
 
+    /// <summary>Displays a file picker and returns the selected path.</summary>
     private static string SelectFile(string filter, string title)
     {
         var dialog = new OpenFileDialog { Filter = filter, Title = title, CheckFileExists = true };
         return dialog.ShowDialog() == true ? dialog.FileName : null;
     }
 
+    /// <summary>Copies a selected folder path into a form field.</summary>
     private void SetFolder(System.Windows.Controls.TextBox target, string title)
     {
         string path = SelectFolder(title);
         if (path is not null) target.Text = path;
     }
 
+    /// <summary>Copies a selected file path into a form field.</summary>
     private static void SetFile(System.Windows.Controls.TextBox target, string filter, string title)
     {
         string path = SelectFile(filter, title);
         if (path is not null) target.Text = path;
     }
 
+    /// <summary>Best-effort cleanup for temporary WAV and extracted-bank directories.</summary>
     private static void DeleteTemporaryDirectory(string path)
     {
         if (path is null || !Directory.Exists(path)) return;

--- a/LegendaryExplorer/LegendaryExplorer/Dialogs/ISACTBankBuilderDialog.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Dialogs/ISACTBankBuilderDialog.xaml.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using LegendaryExplorer.Misc;
+using LegendaryExplorerCore.Packages;
+using LegendaryExplorerCore.Sound.ISACT;
+using LegendaryExplorerCore.Unreal.BinaryConverters;
+using Microsoft.Win32;
+using Microsoft.WindowsAPICodePack.Dialogs;
+using NAudio.Wave;
+
+namespace LegendaryExplorer.Dialogs;
+
+public enum ISACTBankBuildMode
+{
+    Build,
+    Rebuild
+}
+
+public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
+{
+    private sealed record StreamingDataChoice(int UIndex, string DisplayName);
+    private sealed record LocalizationChoice(string Suffix, string DisplayName);
+    private sealed record AuthoringModeChoice(
+        ISACTBankBuilder.AuthoringMode Mode, string DisplayName, string WavTooltip);
+
+    private static readonly LocalizationChoice[] Localizations =
+    [
+        new("", "INT"), new("_DE", "DE"), new("_FR", "FR"),
+        new("_IT", "IT"), new("_PLPC", "PLPC"), new("_RA", "RA")
+    ];
+    private static readonly AuthoringModeChoice[] AuthoringModes =
+    [
+        new(ISACTBankBuilder.AuthoringMode.Conversation, "BioConversation",
+            "Names must end in a numeric string reference, optionally followed by _M or _F."),
+        new(ISACTBankBuilder.AuthoringMode.Codex, "Codex",
+            "The filename becomes the event name and must begin with vo_codex_."),
+        new(ISACTBankBuilder.AuthoringMode.Soundset, "Soundset",
+            "Names end in a three-letter cue plus two digits; racial abilities use sb + variant + two digits, such as sb100."),
+        new(ISACTBankBuilder.AuthoringMode.Music, "Music",
+            "The mus_ bank name is required. Each filename becomes a Sound Event; looping is optional.")
+    ];
+
+    private readonly ISACTBankBuildMode _mode;
+
+    public ISACTBankBuilderDialog(ISACTBankBuildMode mode, Window owner)
+    {
+        _mode = mode;
+        Owner = owner;
+        InitializeComponent();
+        LocalizationComboBox.ItemsSource = Localizations;
+        LocalizationComboBox.SelectedIndex = 0;
+        AuthoringModeComboBox.ItemsSource = AuthoringModes;
+        AuthoringModeComboBox.SelectedIndex = 0;
+
+        string defaultBuilder = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "ISACT", "ISACT SDK", "Win", "Bin", "BankBuilder.exe");
+        if (File.Exists(defaultBuilder)) BankBuilderBox.Text = defaultBuilder;
+
+        bool rebuild = mode == ISACTBankBuildMode.Rebuild;
+        ExistingBankPanel.Visibility = rebuild ? Visibility.Visible : Visibility.Collapsed;
+        ExistingIcbPanel.Visibility = rebuild ? Visibility.Visible : Visibility.Collapsed;
+        BankNameBox.IsEnabled = !rebuild;
+        RunButton.Content = rebuild ? "Rebuild" : "Build";
+        Title = rebuild ? "Rebuild ISACT Banks" : "Build ISACT Banks";
+        DescriptionText.Text = rebuild
+            ? "Compile the new WAVs and append them to an existing final ICB/ISB pair. Existing compressed samples are not recompressed."
+            : "Build new LE1 ICB/ISB banks from WAV files.";
+        SetStreamingDataChoices([]);
+    }
+
+    private void BrowseWavFolder_Click(object sender, RoutedEventArgs e)
+    {
+        string path = SelectFolder("Select the folder containing source WAV files");
+        if (path is null) return;
+        WavFolderBox.Text = path;
+        if (string.IsNullOrWhiteSpace(OutputFolderBox.Text)) OutputFolderBox.Text = Path.Combine(path, "output");
+        if (_mode == ISACTBankBuildMode.Build && string.IsNullOrWhiteSpace(BankNameBox.Text))
+            BankNameBox.Text = new DirectoryInfo(path).Name;
+    }
+
+    private void BrowseOutputFolder_Click(object sender, RoutedEventArgs e) => SetFolder(OutputFolderBox, "Select the output folder");
+    private void BrowseDlcContent_Click(object sender, RoutedEventArgs e) => SetFolder(DlcContentBox, "Select DLC_MOD_Example/Content");
+
+    private void BrowseExistingIcb_Click(object sender, RoutedEventArgs e) =>
+        SetFile(ExistingIcbBox, "ISACT Content Bank (*.icb)|*.icb", "Select the existing ICB");
+
+    private void BrowseExistingIsb_Click(object sender, RoutedEventArgs e)
+    {
+        string path = SelectFile("ISACT Sample Bank (*.isb)|*.isb", "Select the existing ISB");
+        if (path is null) return;
+        ExistingIsbBox.Text = path;
+        string isbName = Path.GetFileNameWithoutExtension(path);
+        LocalizationChoice localization = Localizations.FirstOrDefault(choice =>
+            choice.Suffix.Length > 0 && isbName.EndsWith(choice.Suffix, StringComparison.OrdinalIgnoreCase));
+        if (localization is not null)
+        {
+            BankNameBox.Text = isbName[..^localization.Suffix.Length];
+            LocalizationComboBox.SelectedItem = localization;
+        }
+        else
+        {
+            BankNameBox.Text = isbName;
+            LocalizationComboBox.SelectedIndex = 0;
+        }
+        if (string.IsNullOrWhiteSpace(OutputFolderBox.Text)) OutputFolderBox.Text = Path.GetDirectoryName(path);
+    }
+
+    private void BrowseBankBuilder_Click(object sender, RoutedEventArgs e) =>
+        SetFile(BankBuilderBox, "BankBuilder.exe|BankBuilder.exe|Executable (*.exe)|*.exe", "Select BankBuilder.exe");
+
+    private void BrowseDestinationPcc_Click(object sender, RoutedEventArgs e)
+    {
+        string path = SelectFile("Unreal package (*.pcc;*.upk)|*.pcc;*.upk", "Select the destination LE1 package");
+        if (path is null) return;
+        DestinationPccBox.Text = path;
+        try
+        {
+            LoadStreamingDataChoices(path);
+            SelectPackageLocalization(path);
+        }
+        catch (Exception exception)
+        {
+            SetStreamingDataChoices([]);
+            System.Windows.MessageBox.Show(this, exception.Message, "Could not inspect package",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private async void Run_Click(object sender, RoutedEventArgs e)
+    {
+        string normalizedFolder = null;
+        string extractedIcbDirectory = null;
+        try
+        {
+            ValidateInputs();
+            SetRunning(true, "Checking WAV input...");
+            bool allowNormalisation = NormalizeCheckBox.IsChecked == true;
+            normalizedFolder = await Task.Run(() => PrepareWavInput(WavFolderBox.Text, allowNormalisation));
+
+            int packetSize = int.Parse(PacketSizeBox.Text, CultureInfo.InvariantCulture);
+            float quality = float.Parse(QualityBox.Text, CultureInfo.InvariantCulture);
+            int selectedStreamingData = GetSelectedStreamingDataIndex();
+            string inputIcbPath = ExistingIcbBox.Text;
+            if (_mode == ISACTBankBuildMode.Rebuild && string.IsNullOrWhiteSpace(inputIcbPath))
+            {
+                extractedIcbDirectory = Path.Combine(Path.GetTempPath(), $"LEX_ISACTEmbeddedICB_{Guid.NewGuid():N}");
+                Directory.CreateDirectory(extractedIcbDirectory);
+                inputIcbPath = Path.Combine(extractedIcbDirectory, $"{BankNameBox.Text}.icb");
+                ExtractEmbeddedIcb(DestinationPccBox.Text, selectedStreamingData, ExistingIsbBox.Text, inputIcbPath);
+            }
+
+            SetRunning(true, _mode == ISACTBankBuildMode.Build
+                ? "Building ISACT banks..."
+                : "Compiling and appending new ISACT content...");
+            ISACTBankBuilder.FinalBankFiles result = _mode == ISACTBankBuildMode.Build
+                ? await ISACTBankBuilder.BuildFinalBanksFromWavFolder(
+                    normalizedFolder ?? WavFolderBox.Text, OutputFolderBox.Text, BankNameBox.Text,
+                    BankBuilderBox.Text, packetSize, quality,
+                    sampleBankName: BankNameBox.Text + GetLocalizationSuffix(),
+                    authoringMode: GetAuthoringMode(),
+                    createLoopingMusicQueue: LoopingMusicQueueCheckBox.IsChecked == true)
+                : await ISACTBankBuilder.AppendFinalBanksFromWavFolder(
+                    inputIcbPath, ExistingIsbBox.Text, normalizedFolder ?? WavFolderBox.Text,
+                    OutputFolderBox.Text, BankBuilderBox.Text, packetSize, quality,
+                    authoringMode: GetAuthoringMode());
+
+            if (CopyIsbCheckBox.IsChecked == true)
+            {
+                Directory.CreateDirectory(DlcContentBox.Text);
+                File.Copy(result.ISBPath, Path.Combine(DlcContentBox.Text, Path.GetFileName(result.ISBPath)), true);
+            }
+
+            if (PackageIntegrationCheckBox.IsChecked == true)
+            {
+                SetRunning(true, "Updating BioSoundNodeWaveStreamingData...");
+                await Task.Run(() => InstallStreamingData(
+                    DestinationPccBox.Text, selectedStreamingData, BankNameBox.Text,
+                    GetLocalizationSuffix(), result.ICBPath, result.ISBPath));
+            }
+
+            SetRunning(false, $"Created {result.EventMappings.Count} sound events.\n{result.ICBPath}\n{result.ISBPath}");
+            System.Windows.MessageBox.Show(this, "ISACT bank operation completed successfully.", Title,
+                MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+        catch (Exception exception)
+        {
+            SetRunning(false, exception.Message);
+            System.Windows.MessageBox.Show(this, exception.Message, "ISACT bank operation failed",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(normalizedFolder);
+            DeleteTemporaryDirectory(extractedIcbDirectory);
+        }
+    }
+
+    private void ValidateInputs()
+    {
+        if (!Directory.Exists(WavFolderBox.Text)) throw new DirectoryNotFoundException("Select a valid WAV source folder.");
+        if (string.IsNullOrWhiteSpace(OutputFolderBox.Text)) throw new InvalidDataException("Select an output folder.");
+        if (string.IsNullOrWhiteSpace(BankNameBox.Text)) throw new InvalidDataException("Enter a bank name.");
+        if (!File.Exists(BankBuilderBox.Text)) throw new FileNotFoundException("Select BankBuilder.exe.", BankBuilderBox.Text);
+        if (!int.TryParse(PacketSizeBox.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int packet) || packet < 0)
+            throw new InvalidDataException("Stream packet size must be a non-negative integer.");
+        if (!float.TryParse(QualityBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out float quality) || quality is < 0 or > 1)
+            throw new InvalidDataException("Vorbis quality must be between 0 and 1.");
+        if (_mode == ISACTBankBuildMode.Rebuild && !File.Exists(ExistingIsbBox.Text))
+            throw new FileNotFoundException("Select an existing ISB.");
+        if (_mode == ISACTBankBuildMode.Rebuild && LoopingMusicQueueCheckBox.IsChecked == true)
+            throw new InvalidDataException("Appending to an existing music queue is not yet supported.");
+        if (CopyIsbCheckBox.IsChecked == true && string.IsNullOrWhiteSpace(DlcContentBox.Text))
+            throw new InvalidDataException("Select the DLC Content folder.");
+
+        bool packageNeeded = PackageIntegrationCheckBox.IsChecked == true ||
+                             (_mode == ISACTBankBuildMode.Rebuild && string.IsNullOrWhiteSpace(ExistingIcbBox.Text));
+        if (packageNeeded && !File.Exists(DestinationPccBox.Text))
+            throw new FileNotFoundException("Select the package containing the target BioStreamingData.");
+        if (packageNeeded && GetPackageLocalizationSuffix(DestinationPccBox.Text) != GetLocalizationSuffix())
+            throw new InvalidDataException(
+                "The selected localisation does not match the destination LOC package.");
+        if (packageNeeded && _mode == ISACTBankBuildMode.Rebuild && GetSelectedStreamingDataIndex() <= 0)
+            throw new InvalidDataException("Select the existing BioStreamingData export to rebuild.");
+        if (_mode == ISACTBankBuildMode.Rebuild && !string.IsNullOrWhiteSpace(ExistingIcbBox.Text) && !File.Exists(ExistingIcbBox.Text))
+            throw new FileNotFoundException("The optional existing ICB could not be found.", ExistingIcbBox.Text);
+    }
+
+    private static string PrepareWavInput(string sourceFolder, bool allowNormalisation)
+    {
+        string[] files = Directory.GetFiles(sourceFolder, "*.wav", SearchOption.TopDirectoryOnly);
+        if (files.Length == 0) throw new InvalidDataException("The selected folder contains no WAV files.");
+
+        bool requiresConversion = false;
+        foreach (string file in files)
+        {
+            using var reader = new WaveFileReader(file);
+            if (reader.WaveFormat.Channels is not (1 or 2))
+                throw new InvalidDataException($"ISACT audio must be mono or stereo: {Path.GetFileName(file)}");
+            requiresConversion |= reader.WaveFormat.Encoding != WaveFormatEncoding.Pcm || reader.WaveFormat.BitsPerSample != 16;
+        }
+        if (!requiresConversion) return null;
+        if (!allowNormalisation)
+            throw new InvalidDataException("One or more WAV files are not signed 16-bit PCM. Enable automatic conversion or clean the sources first.");
+
+        string convertedFolder = Path.Combine(Path.GetTempPath(), $"LEX_ISACT_PCM16_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(convertedFolder);
+        foreach (string file in files)
+        {
+            string destination = Path.Combine(convertedFolder, Path.GetFileName(file));
+            using var reader = new WaveFileReader(file);
+            if (reader.WaveFormat.Encoding == WaveFormatEncoding.Pcm && reader.WaveFormat.BitsPerSample == 16)
+                File.Copy(file, destination);
+            else
+                WaveFileWriter.CreateWaveFile16(destination, reader.ToSampleProvider());
+        }
+        return convertedFolder;
+    }
+
+    private void LoadStreamingDataChoices(string packagePath)
+    {
+        using IMEPackage package = MEPackageHandler.OpenMEPackage(packagePath, forceLoadFromDisk: true);
+        if (package.Game != MEGame.LE1) throw new InvalidDataException("The selected package is not an LE1 package.");
+        var choices = new List<StreamingDataChoice>();
+        if (_mode == ISACTBankBuildMode.Build) choices.Add(new StreamingDataChoice(0, "<Create new BioStreamingData>"));
+        choices.AddRange(package.Exports.Where(export => export.ClassName == "BioSoundNodeWaveStreamingData")
+            .Select(export => new StreamingDataChoice(export.UIndex, DescribeStreamingData(export))));
+        SetStreamingDataChoices(choices);
+    }
+
+    private void SelectPackageLocalization(string packagePath)
+    {
+        string suffix = GetPackageLocalizationSuffix(packagePath);
+        LocalizationComboBox.SelectedItem = Localizations.Single(choice => choice.Suffix == suffix);
+    }
+
+    private string GetLocalizationSuffix() =>
+        (LocalizationComboBox.SelectedItem as LocalizationChoice)?.Suffix ?? "";
+
+    private ISACTBankBuilder.AuthoringMode GetAuthoringMode() =>
+        (AuthoringModeComboBox.SelectedItem as AuthoringModeChoice)?.Mode
+        ?? ISACTBankBuilder.AuthoringMode.Conversation;
+
+    private void AuthoringModeComboBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+    {
+        if (WavFolderBox is null || AuthoringModeComboBox.SelectedItem is not AuthoringModeChoice choice) return;
+        WavFolderBox.ToolTip = choice.WavTooltip;
+        LoopingMusicQueueCheckBox.Visibility = choice.Mode == ISACTBankBuilder.AuthoringMode.Music
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        if (choice.Mode != ISACTBankBuilder.AuthoringMode.Music)
+            LoopingMusicQueueCheckBox.IsChecked = false;
+        if (choice.Mode == ISACTBankBuilder.AuthoringMode.Music && PacketSizeBox?.Text == "2500")
+            PacketSizeBox.Text = "2000";
+    }
+
+    private static string GetPackageLocalizationSuffix(string packagePath)
+    {
+        MELocalization localization = Path.GetFileNameWithoutExtension(packagePath).GetUnrealLocalization();
+        return localization switch
+        {
+            MELocalization.None or MELocalization.INT => "",
+            MELocalization.DEU => "_DE",
+            MELocalization.FRA => "_FR",
+            MELocalization.ITA => "_IT",
+            MELocalization.POL => "_PLPC",
+            MELocalization.RUS => "_RA",
+            _ => throw new InvalidDataException(
+                $"'{Path.GetFileName(packagePath)}' is not a supported LE1 LOC package name.")
+        };
+    }
+
+    private static string DescribeStreamingData(ExportEntry export)
+    {
+        string bankTitle = null;
+        try
+        {
+            bankTitle = export.GetBinaryData<BioSoundNodeWaveStreamingData>().BankPair.ICBBank.BankChunks
+                .OfType<TitleBankChunk>().FirstOrDefault()?.Value;
+        }
+        catch { }
+        return bankTitle is null
+            ? $"#{export.UIndex} {export.InstancedFullPath}"
+            : $"#{export.UIndex} {export.InstancedFullPath} - {bankTitle}";
+    }
+
+    private void SetStreamingDataChoices(IReadOnlyCollection<StreamingDataChoice> choices)
+    {
+        StreamingDataComboBox.ItemsSource = choices;
+        StreamingDataComboBox.SelectedIndex = choices.Count > 0 ? 0 : -1;
+    }
+
+    private int GetSelectedStreamingDataIndex() =>
+        StreamingDataComboBox.SelectedItem is StreamingDataChoice choice ? choice.UIndex : -1;
+
+    private static void ExtractEmbeddedIcb(
+        string packagePath, int streamingDataUIndex, string existingIsbPath, string outputPath)
+    {
+        using IMEPackage package = MEPackageHandler.OpenMEPackage(packagePath, forceLoadFromDisk: true);
+        ExportEntry streamingData = GetStreamingDataExport(package, streamingDataUIndex);
+        string embeddedIsbTitle = streamingData.GetBinaryData<BioSoundNodeWaveStreamingData>().BankPair.ISBBank.BankChunks
+            .OfType<TitleBankChunk>().FirstOrDefault()?.Value;
+        string externalIsbTitle;
+        using (var stream = File.OpenRead(existingIsbPath))
+            externalIsbTitle = new ISACTBank(stream).BankChunks.OfType<TitleBankChunk>().FirstOrDefault()?.Value;
+        if (!string.Equals(embeddedIsbTitle, externalIsbTitle, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidDataException(
+                $"The selected BioStreamingData references '{embeddedIsbTitle}', but the existing ISB is '{externalIsbTitle}'.");
+        ISACTHelper.ExportStreamingDataContentBank(streamingData, outputPath);
+    }
+
+    private static void InstallStreamingData(
+        string destinationPath, int streamingDataUIndex, string bankName, string localizationSuffix,
+        string icbPath, string isbPath)
+    {
+        using IMEPackage destination = MEPackageHandler.OpenMEPackage(destinationPath, forceLoadFromDisk: true);
+        if (destination.Game != MEGame.LE1)
+            throw new InvalidDataException("BioSoundNodeWaveStreamingData generation is only supported for LE1 packages.");
+
+        if (streamingDataUIndex > 0)
+            ISACTHelper.GenerateSoundNodeWaveStreamingDataCS(
+                GetStreamingDataExport(destination, streamingDataUIndex), icbPath, isbPath);
+        else
+            ISACTHelper.CreateSoundNodeWaveStreamingData(
+                destination, bankName, icbPath, isbPath, localizationSuffix);
+        destination.Save();
+    }
+
+    private static ExportEntry GetStreamingDataExport(IMEPackage package, int uIndex)
+    {
+        if (!package.TryGetUExport(uIndex, out ExportEntry export) || export.ClassName != "BioSoundNodeWaveStreamingData")
+            throw new InvalidDataException($"Export #{uIndex} is not BioSoundNodeWaveStreamingData.");
+        return export;
+    }
+
+    private void SetRunning(bool running, string status)
+    {
+        RunButton.IsEnabled = !running;
+        Progress.Visibility = running ? Visibility.Visible : Visibility.Collapsed;
+        StatusText.Text = status;
+    }
+
+    private void Cancel_Click(object sender, RoutedEventArgs e) => Close();
+
+    private string SelectFolder(string title)
+    {
+        var dialog = new CommonOpenFileDialog(title) { IsFolderPicker = true };
+        return dialog.ShowDialog(this) == CommonFileDialogResult.Ok ? dialog.FileName : null;
+    }
+
+    private static string SelectFile(string filter, string title)
+    {
+        var dialog = new OpenFileDialog { Filter = filter, Title = title, CheckFileExists = true };
+        return dialog.ShowDialog() == true ? dialog.FileName : null;
+    }
+
+    private void SetFolder(System.Windows.Controls.TextBox target, string title)
+    {
+        string path = SelectFolder(title);
+        if (path is not null) target.Text = path;
+    }
+
+    private static void SetFile(System.Windows.Controls.TextBox target, string filter, string title)
+    {
+        string path = SelectFile(filter, title);
+        if (path is not null) target.Text = path;
+    }
+
+    private static void DeleteTemporaryDirectory(string path)
+    {
+        if (path is null || !Directory.Exists(path)) return;
+        try { Directory.Delete(path, true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}

--- a/LegendaryExplorer/LegendaryExplorer/Dialogs/ISACTBankBuilderDialog.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Dialogs/ISACTBankBuilderDialog.xaml.cs
@@ -59,7 +59,7 @@ public partial class ISACTBankBuilderDialog : NotifyPropertyChangedWindowBase
         new(ISACTBankBuilder.AuthoringMode.Conversation, "BioConversation",
             "Names must end in a numeric string reference, optionally followed by _M or _F."),
         new(ISACTBankBuilder.AuthoringMode.Codex, "Codex",
-            "The filename becomes the event name and must begin with vo_codex_."),
+            "Names use vo_codex_, optionally preceded by an LE1 audio locale such as EN_."),
         new(ISACTBankBuilder.AuthoringMode.Soundset, "Soundset",
             "Names end in a three-letter cue plus two digits; racial abilities use sb + variant + two digits, such as sb100."),
         new(ISACTBankBuilder.AuthoringMode.Music, "Music",

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Soundplorer/SoundplorerWPF.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Soundplorer/SoundplorerWPF.xaml
@@ -76,6 +76,12 @@
                     <Separator/>
                     <MenuItem Name="Recents_MenuItem" Header="Recent" IsEnabled="false"/>
                 </MenuItem>
+                <MenuItem Header="_ISACT" Padding="4">
+                    <MenuItem Header="Build ISACT Banks" Click="BuildISACTBanks_Clicked"/>
+                    <MenuItem Header="Rebuild ISACT Banks" Click="RebuildISACTBanks_Clicked"/>
+                    <Separator/>
+                    <MenuItem Header="Extract all audio from this file" Click="ExtractAllAudio_Clicked" IsEnabled="{Binding AudioFileLoaded, Converter={StaticResource NullEnabledConverter}}"/>
+                </MenuItem>
                 <MenuItem Header="_Wwise" Padding="4">
                     <MenuItem Header="Set Wwise executable paths" Click="SetWwisePaths_Clicked"/>
                     <MenuItem Header="Extract all audio from this file" Click="ExtractAllAudio_Clicked" IsEnabled="{Binding AudioFileLoaded, Converter={StaticResource NullEnabledConverter}}"/>

--- a/LegendaryExplorer/LegendaryExplorer/Tools/Soundplorer/SoundplorerWPF.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/Tools/Soundplorer/SoundplorerWPF.xaml.cs
@@ -43,6 +43,7 @@ namespace LegendaryExplorer.Tools.Soundplorer
     public partial class SoundplorerWPF : WPFBase, IBusyUIHost, IRecents
     {
         private string LoadedISBFile;
+        internal string LoadedISBFilePath => LoadedISBFile;
         private string LoadedAFCFile;
         BackgroundWorker backgroundScanner;
         public ObservableCollectionExtended<object> BindedItemsList { get; set; } = new();
@@ -888,6 +889,18 @@ namespace LegendaryExplorer.Tools.Soundplorer
         {
             SetWwisePathDialog swpd = new ();
             swpd.ShowDialog();
+        }
+
+        internal void ReloadLoadedISB() => LoadISB();
+
+        private void BuildISACTBanks_Clicked(object sender, RoutedEventArgs e)
+        {
+            new ISACTBankBuilderDialog(ISACTBankBuildMode.Build, this).ShowDialog();
+        }
+
+        private void RebuildISACTBanks_Clicked(object sender, RoutedEventArgs e)
+        {
+            new ISACTBankBuilderDialog(ISACTBankBuildMode.Rebuild, this).ShowDialog();
         }
 
         private void ExtractAllAudio_Clicked(object sender, RoutedEventArgs e)

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/Soundpanel/Soundpanel.xaml
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/Soundpanel/Soundpanel.xaml
@@ -80,7 +80,7 @@
                                 <Setter Property="ToolTip" Value="Change audio by importing a Wave file"/>
                                 <Style.Triggers>
                                     <Trigger Property="IsEnabled" Value="False">
-                                        <Setter Property="ToolTip" Value="Change audio by importing a Wave file&#x0a;You may only replace audio from a package file, not an audio bank"/>
+                                        <Setter Property="ToolTip" Value="Change audio by importing a Wave file&#x0a;Select a replaceable audio entry first"/>
                                     </Trigger>
                                     <DataTrigger Binding="{Binding CurrentLoadedExport.FileRef.Game}" Value="ME2">
                                         <Setter Property="ToolTip" Value="Change audio by importing a Wave file&#x0a;It is not possible to replace audio in ME2"/>

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/Soundpanel/Soundpanel.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/Soundpanel/Soundpanel.xaml.cs
@@ -1340,6 +1340,9 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
 
         #region Audio Replacement
 
+        /// <summary>
+        /// Determines whether the selected ISACT sample or package audio export supports replacement.
+        /// </summary>
         private bool CanReplaceAudio(object obj)
         {
             if (CurrentLoadedISACTEntry != null && HostingControl is SoundplorerWPF soundplorer)
@@ -1367,10 +1370,14 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
             return false;
         }
 
+        /// <summary>
+        /// Dispatches replacement to the handler for an external ISB sample or package audio export.
+        /// </summary>
         private async void ReplaceAudio(object obj)
         {
             if (CurrentLoadedISACTEntry != null)
             {
+                // External ISB samples require BankBuilder rather than the embedded-audio replacement paths.
                 await ReplaceExternalISBSample();
                 return;
             }
@@ -1391,6 +1398,9 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
             }
         }
 
+        /// <summary>
+        /// Replaces the selected external ISB sample and optionally refreshes its package metadata.
+        /// </summary>
         private async Task ReplaceExternalISBSample()
         {
             if (CurrentLoadedISACTEntry == null || HostingControl is not SoundplorerWPF soundplorer ||
@@ -1406,6 +1416,7 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
             if (audioDialog.ShowDialog(Window.GetWindow(this)) != true)
                 return;
 
+            // ISB offsets change after replacement, so the stripped metadata in the package may also need updating.
             string packagePath = null;
             MessageBoxResult updatePackage = MessageBox.Show(
                 "A replacement changes compressed sizes and external ISB offsets. The matching BioSoundNodeWaveStreamingData should also be refreshed.\n\nSelect the package containing it now?",
@@ -1436,6 +1447,7 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
             string normalizedWave = Path.Combine(Path.GetTempPath(), $"LEX_ISACTReplaceInput_{Guid.NewGuid():N}.wav");
             try
             {
+                // BankBuilder expects PCM16 input; normalisation is isolated from the user's source file.
                 using (var reader = new AudioFileReader(audioDialog.FileName))
                     WaveFileWriter.CreateWaveFile16(normalizedWave, reader);
                 using (var waveReader = new WaveFileReader(normalizedWave))
@@ -1459,6 +1471,7 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
                     bankBuilderPath = builderDialog.FileName;
                 }
 
+                // Release the loaded ISB before replacing it on disk.
                 FreeAudioResources();
                 HostingControl.IsBusy = true;
                 HostingControl.BusyText = "Compiling and replacing ISACT sample";
@@ -1469,6 +1482,7 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
                 Exception metadataError = null;
                 if (packagePath is not null)
                 {
+                    // Sample offsets are stored in the package, but a failed refresh must not undo the ISB replacement.
                     try
                     {
                         await Task.Run(() => RefreshExternalISBMetadata(packagePath, result.ISBPath));
@@ -1506,6 +1520,9 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
             }
         }
 
+        /// <summary>
+        /// Finds the matching streaming-data export by ISB title and replaces its stripped ISB metadata.
+        /// </summary>
         private static void RefreshExternalISBMetadata(string packagePath, string isbPath)
         {
             string isbTitle;

--- a/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/Soundpanel/Soundpanel.xaml.cs
+++ b/LegendaryExplorer/LegendaryExplorer/UserControls/ExportLoaderControls/Soundpanel/Soundpanel.xaml.cs
@@ -1342,6 +1342,8 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
 
         private bool CanReplaceAudio(object obj)
         {
+            if (CurrentLoadedISACTEntry != null && HostingControl is SoundplorerWPF soundplorer)
+                return File.Exists(soundplorer.LoadedISBFilePath);
             if (CurrentLoadedExport == null) return false;
             if (CurrentLoadedExport.IsDefaultObject) return false;
             if (CurrentLoadedExport.ClassName == "WwiseStream")
@@ -1367,6 +1369,11 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
 
         private async void ReplaceAudio(object obj)
         {
+            if (CurrentLoadedISACTEntry != null)
+            {
+                await ReplaceExternalISBSample();
+                return;
+            }
             if (CurrentLoadedExport == null) return;
             if (CurrentLoadedExport.ClassName == "WwiseStream")
             {
@@ -1382,6 +1389,156 @@ namespace LegendaryExplorer.UserControls.ExportLoaderControls
             {
                 ReplaceEmbeddedSoundNodeWave();
             }
+        }
+
+        private async Task ReplaceExternalISBSample()
+        {
+            if (CurrentLoadedISACTEntry == null || HostingControl is not SoundplorerWPF soundplorer ||
+                !File.Exists(soundplorer.LoadedISBFilePath))
+                return;
+
+            var audioDialog = new OpenFileDialog
+            {
+                Title = $"Replace {CurrentLoadedISACTEntry.TitleInfo.Value}",
+                Filter = "Wave PCM (*.wav)|*.wav",
+                CustomPlaces = AppDirectories.GameCustomPlaces
+            };
+            if (audioDialog.ShowDialog(Window.GetWindow(this)) != true)
+                return;
+
+            string packagePath = null;
+            MessageBoxResult updatePackage = MessageBox.Show(
+                "A replacement changes compressed sizes and external ISB offsets. The matching BioSoundNodeWaveStreamingData should also be refreshed.\n\nSelect the package containing it now?",
+                "Refresh LE1 streaming metadata", MessageBoxButton.YesNoCancel, MessageBoxImage.Question);
+            if (updatePackage == MessageBoxResult.Cancel)
+                return;
+            if (updatePackage == MessageBoxResult.Yes)
+            {
+                var packageDialog = new OpenFileDialog
+                {
+                    Title = "Select the package containing BioSoundNodeWaveStreamingData",
+                    Filter = "Unreal package (*.pcc;*.upk)|*.pcc;*.upk",
+                    CustomPlaces = AppDirectories.GameCustomPlaces
+                };
+                if (packageDialog.ShowDialog(Window.GetWindow(this)) != true)
+                    return;
+                packagePath = packageDialog.FileName;
+            }
+
+            IntBankChunk sampleIndexChunk = CurrentLoadedISACTEntry.GetChunk("indx") as IntBankChunk;
+            if (sampleIndexChunk is null)
+            {
+                MessageBox.Show("The selected ISACT sample has no resource index.", "Cannot replace sample",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            string normalizedWave = Path.Combine(Path.GetTempPath(), $"LEX_ISACTReplaceInput_{Guid.NewGuid():N}.wav");
+            try
+            {
+                using (var reader = new AudioFileReader(audioDialog.FileName))
+                    WaveFileWriter.CreateWaveFile16(normalizedWave, reader);
+                using (var waveReader = new WaveFileReader(normalizedWave))
+                {
+                    if (waveReader.WaveFormat.Channels is not (1 or 2))
+                        throw new InvalidDataException("ISACT audio must be mono or stereo.");
+                }
+
+                string bankBuilderPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                    "ISACT", "ISACT SDK", "Win", "Bin", "BankBuilder.exe");
+                if (!File.Exists(bankBuilderPath))
+                {
+                    var builderDialog = new OpenFileDialog
+                    {
+                        Title = "Select BankBuilder.exe",
+                        Filter = "BankBuilder.exe|BankBuilder.exe|Executable (*.exe)|*.exe"
+                    };
+                    if (builderDialog.ShowDialog(Window.GetWindow(this)) != true)
+                        return;
+                    bankBuilderPath = builderDialog.FileName;
+                }
+
+                FreeAudioResources();
+                HostingControl.IsBusy = true;
+                HostingControl.BusyText = "Compiling and replacing ISACT sample";
+                var result = await ISACTBankBuilder.ReplaceFinalBankSampleFromWave(
+                    soundplorer.LoadedISBFilePath, sampleIndexChunk.Value, normalizedWave,
+                    soundplorer.LoadedISBFilePath, bankBuilderPath);
+
+                Exception metadataError = null;
+                if (packagePath is not null)
+                {
+                    try
+                    {
+                        await Task.Run(() => RefreshExternalISBMetadata(packagePath, result.ISBPath));
+                    }
+                    catch (Exception exception)
+                    {
+                        metadataError = exception;
+                    }
+                }
+
+                soundplorer.ReloadLoadedISB();
+                if (metadataError is not null)
+                {
+                    MessageBox.Show(
+                        $"Replaced sample {result.SampleIndex}: {result.SampleName}\n\nThe BioStreamingData metadata could not be refreshed:\n{metadataError.Message}",
+                        "ISACT sample replaced", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
+                string packageMessage = packagePath is null
+                    ? "\n\nThe ISB was updated, but the package metadata was not. Refresh its BioStreamingData before testing in game."
+                    : "\n\nThe matching BioStreamingData metadata was also refreshed.";
+                MessageBox.Show($"Replaced sample {result.SampleIndex}: {result.SampleName}{packageMessage}",
+                    "ISACT sample replaced", MessageBoxButton.OK,
+                    packagePath is null ? MessageBoxImage.Warning : MessageBoxImage.Information);
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show(exception.Message, "ISACT replacement failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                HostingControl.IsBusy = false;
+                if (File.Exists(normalizedWave)) File.Delete(normalizedWave);
+            }
+        }
+
+        private static void RefreshExternalISBMetadata(string packagePath, string isbPath)
+        {
+            string isbTitle;
+            using (var stream = File.OpenRead(isbPath))
+            {
+                var bank = new ISACTBank(stream);
+                isbTitle = bank.BankChunks.OfType<TitleBankChunk>().FirstOrDefault()?.Value
+                    ?? throw new InvalidDataException("The updated ISB has no bank title.");
+            }
+
+            using IMEPackage package = MEPackageHandler.OpenMEPackage(packagePath, forceLoadFromDisk: true);
+            if (package.Game != MEGame.LE1)
+                throw new InvalidDataException("The streaming-data package must be an LE1 package.");
+            var matches = package.Exports.Where(export => export.ClassName == "BioSoundNodeWaveStreamingData")
+                .Where(export =>
+                {
+                    try
+                    {
+                        string embeddedTitle = export.GetBinaryData<BioSoundNodeWaveStreamingData>().BankPair.ISBBank
+                            .BankChunks.OfType<TitleBankChunk>().FirstOrDefault()?.Value;
+                        return embeddedTitle?.Equals(isbTitle, StringComparison.OrdinalIgnoreCase) == true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                }).ToList();
+            if (matches.Count != 1)
+                throw new InvalidDataException(
+                    $"Expected exactly one BioStreamingData export for '{isbTitle}' in the selected package, but found {matches.Count}.");
+
+            ISACTHelper.RefreshStreamingDataSampleBank(matches[0], isbPath);
+            package.Save();
         }
 
         private void ReplaceEmbeddedSoundNodeWave()

--- a/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTBankBuilder.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTBankBuilder.cs
@@ -911,13 +911,18 @@ public static partial class ISACTBankBuilder
     private static string GetNamedEventName(WaveSample sample, AuthoringMode authoringMode)
     {
         string fileBaseName = Path.GetFileNameWithoutExtension(sample.FileName);
-        if (authoringMode is AuthoringMode.Codex or AuthoringMode.Music)
+        if (authoringMode == AuthoringMode.Codex)
         {
-            if (authoringMode == AuthoringMode.Codex &&
-                !fileBaseName.StartsWith("vo_codex_", StringComparison.OrdinalIgnoreCase))
-                throw new InvalidDataException($"Codex WAV names must begin with 'vo_codex_': {sample.FileName}");
-            return fileBaseName;
+            Match codexMatch = CodexFileNameRegex().Match(fileBaseName);
+            if (!codexMatch.Success)
+                throw new InvalidDataException(
+                    $"Codex WAV names must contain 'vo_codex_', optionally preceded by an LE1 audio locale: {sample.FileName}");
+
+            return codexMatch.Groups["event"].Value;
         }
+
+        if (authoringMode == AuthoringMode.Music)
+            return fileBaseName;
 
         Match match = SoundsetFileNameRegex().Match(fileBaseName);
         if (!match.Success)
@@ -1187,6 +1192,9 @@ public static partial class ISACTBankBuilder
 
     [GeneratedRegex(@"(?<id>\d+)(?:_(?<gender>[FM]))?$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex DialogueFileNameRegex();
+
+    [GeneratedRegex(@"^(?:(?:EN|DE|FR|IT|PLPC|RA)_)?(?<event>vo_codex_.+)$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex CodexFileNameRegex();
 
     [GeneratedRegex(@"_(?:sb(?<racialVariant>\d)|(?<code>[A-Za-z]{3}))(?<index>\d{2})$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex SoundsetFileNameRegex();

--- a/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTBankBuilder.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTBankBuilder.cs
@@ -13,9 +13,14 @@ using System.Threading.Tasks;
 
 namespace LegendaryExplorerCore.Sound.ISACT;
 
-// Builds LE1 ISACT content and sample banks from PCM WAV files.
+/// <summary>
+/// Authors and modifies LE1 ISACT content and sample banks from PCM WAV files.
+/// </summary>
 public static partial class ISACTBankBuilder
 {
+    /// <summary>
+    /// Determines how WAV filenames are converted to ISACT Sound Event names.
+    /// </summary>
     public enum AuthoringMode
     {
         Conversation,
@@ -25,35 +30,41 @@ public static partial class ISACTBankBuilder
     }
 
     private const int InvalidResourceIndex = int.MinValue;
-    private const int DefaultTimeCode = 0x00190028;
+    // Default object metadata written by ISACT Production Studio.
+    private const int DefaultTimeCode = 0x00190028; // 1,638,440
     private const int DefaultTempo = 500000;
-    private const int DefaultTimeSignature = 0x00040004;
-    private const int DefaultSection = unchecked((int)0xE0000000);
+    private const int DefaultTimeSignature = 0x00040004; // 262,148
+    private const int DefaultSection = -536_870_912; // Signed form of 0xE0000000
     private const int ContentIndexEntriesPerPage = 50;
+    // LE1 uses signed 32-bit offsets when reading external sample data.
+    private const long MaximumFinalIsbSize = int.MaxValue;
 
-    // Describes an event-to-sample link created from the WAV filenames.
+    /// <summary>Describes an event-to-sample link created from a WAV filename.</summary>
     public sealed record EventMapping(string EventName, string SampleFileName, int SampleIndex);
 
-    // Source banks and their event mappings.
+    /// <summary>Contains uncompressed source banks and their event mappings.</summary>
     public sealed record SourceBankResult(ISACTBankPair Banks, IReadOnlyList<EventMapping> EventMappings);
 
-    // Paths written by WriteSourceBanksFromWavFolder.
+    /// <summary>Contains paths written for BankBuilder and their event mappings.</summary>
     public sealed record SourceBankFiles(string ICBPath, string ISBPath, IReadOnlyList<EventMapping> EventMappings);
 
-    // Final Ogg Vorbis banks produced by BankBuilder.
+    /// <summary>Contains final Ogg Vorbis banks produced by BankBuilder.</summary>
     public sealed record FinalBankFiles(
         string ICBPath,
         string ISBPath,
         string BuilderLog,
         IReadOnlyList<EventMapping> EventMappings);
 
+    /// <summary>Describes a compiled sample replacement.</summary>
     public sealed record SampleReplacementResult(
         string ISBPath,
         string BuilderLog,
         int SampleIndex,
         string SampleName);
 
-    // Appends compiled samples and events without recompressing existing samples.
+    /// <summary>
+    /// Appends compiled samples and Sound Events without recompressing existing samples.
+    /// </summary>
     public static ISACTBankPair AppendCompiledBanks(ISACTBankPair existing, ISACTBankPair additions)
     {
         ArgumentNullException.ThrowIfNull(existing);
@@ -76,14 +87,14 @@ public static partial class ISACTBankBuilder
         foreach (ISACTListBankChunk sample in addedSamples)
         {
             IntBankChunk index = GetRequiredIndex(sample);
-            index.Value = checked(index.Value + sampleBase);
+            index.Value += sampleBase;
             existing.ISBBank.BankChunks.Add(sample);
         }
 
         foreach (ISACTListBankChunk soundEvent in addedEvents)
         {
             IntBankChunk index = GetRequiredIndex(soundEvent);
-            index.Value = checked(index.Value + eventBase);
+            index.Value += eventBase;
             RebaseSoundEventSamples(soundEvent, sampleBase, addedSamples.Count);
             existing.ICBBank.BankChunks.Add(soundEvent);
         }
@@ -91,7 +102,8 @@ public static partial class ISACTBankBuilder
         ContentIndexBankChunk contentIndex = existing.ICBBank.BankChunks
             .OfType<ContentIndexBankChunk>()
             .SingleOrDefault()
-            ?? throw new InvalidDataException("The existing ICB does not contain a content index.");
+            ?? throw new InvalidDataException(
+                "The existing ICB has no content index, so its Sound Events cannot be appended. Rebuild the original bank before adding content.");
         IReadOnlyList<IndexEntry> existingIndexEntries = contentIndex.IndexPages
             .SelectMany(page => page.IndexEntries)
             .ToList();
@@ -100,14 +112,16 @@ public static partial class ISACTBankBuilder
             {
                 Title = soundEvent.TitleInfo.Value,
                 ObjectType = "snde",
-                ObjectIndex = checked((uint)(eventBase + localIndex))
+                ObjectIndex = (uint)(eventBase + localIndex)
             }))
             .ToArray();
         contentIndex.IndexPages = CreateIndexPages(mergedIndexEntries);
         return existing;
     }
 
-    // Replaces one compiled sample while preserving its resource index and title.
+    /// <summary>
+    /// Replaces one compiled sample while preserving its resource index and title.
+    /// </summary>
     public static void ReplaceCompiledSample(
         ISACTBank existingIsb,
         int sampleIndex,
@@ -150,6 +164,7 @@ public static partial class ISACTBankBuilder
         Male
     }
 
+    /// <summary>Contains the filename metadata and PCM format required to serialize one ISACT sample.</summary>
     private sealed record WaveSample(
         string FilePath,
         string FileName,
@@ -161,6 +176,8 @@ public static partial class ISACTBankBuilder
         ushort BlockAlign,
         byte[] PCMData);
 
+    // Maps filename cue suffixes to Sound Event stems. Values were derived by comparing sample
+    // filenames with Sound Event titles in shipped LE1 Soundset ICBs.
     private static readonly IReadOnlyDictionary<string, string> SoundsetEventNames =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -178,7 +195,9 @@ public static partial class ISACTBankBuilder
             ["vsd"] = "VehicleShieldsDown"
         };
 
-    // Creates BankBuilder-ready PCM banks from a WAV folder.
+    /// <summary>
+    /// Creates BankBuilder-ready PCM banks from the WAV files in a folder.
+    /// </summary>
     public static SourceBankResult CreateSourceBanksFromWavFolder(
         string wavFolderPath,
         string bankName,
@@ -225,7 +244,9 @@ public static partial class ISACTBankBuilder
         return new SourceBankResult(new ISACTBankPair { ICBBank = icb, ISBBank = isb }, eventMappings);
     }
 
-    // Writes PCM ICB and ISB files for BankBuilder.
+    /// <summary>
+    /// Writes PCM ICB and ISB source files for BankBuilder.
+    /// </summary>
     public static SourceBankFiles WriteSourceBanksFromWavFolder(
         string wavFolderPath,
         string outputDirectory,
@@ -252,7 +273,9 @@ public static partial class ISACTBankBuilder
         return new SourceBankFiles(icbPath, isbPath, result.EventMappings);
     }
 
-    // Builds and validates final banks with BankBuilder.
+    /// <summary>
+    /// Authors source banks, runs BankBuilder, and validates its final Ogg Vorbis output.
+    /// </summary>
     public static async Task<FinalBankFiles> BuildFinalBanksFromWavFolder(
         string wavFolderPath,
         string outputDirectory,
@@ -266,8 +289,6 @@ public static partial class ISACTBankBuilder
         AuthoringMode authoringMode = AuthoringMode.Conversation,
         bool createLoopingMusicQueue = false)
     {
-        if (!OperatingSystem.IsWindows())
-            throw new PlatformNotSupportedException("The official ISACT BankBuilder is a Windows executable.");
         ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectory);
         ArgumentException.ThrowIfNullOrWhiteSpace(bankBuilderPath);
         sampleBankName ??= bankName;
@@ -276,6 +297,7 @@ public static partial class ISACTBankBuilder
             throw new ArgumentOutOfRangeException(nameof(compressionQuality), "Compression quality must be between 0 and 1.");
 
         string bankBuilderExe = ResolveBankBuilderExecutable(bankBuilderPath);
+        // Isolate BankBuilder because it discovers codec DLLs and writes BuilderLog.txt in its working directory.
         string stagingRoot = Path.Combine(Path.GetTempPath(), $"LEX_ISACTBankBuilder_{Guid.NewGuid():N}");
         string toolDirectory = Path.Combine(stagingRoot, "tool");
         string sourceDirectory = Path.Combine(stagingRoot, "source");
@@ -311,6 +333,7 @@ public static partial class ISACTBankBuilder
                 RedirectStandardError = true
             };
 
+            // Capture both process streams and the file log because BankBuilder reports failures through either channel.
             using var process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException("BankBuilder could not be started.");
             Task<string> standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
@@ -394,7 +417,9 @@ public static partial class ISACTBankBuilder
         }
     }
 
-    // Compiles and appends new WAVs without recompressing existing samples.
+    /// <summary>
+    /// Compiles new WAVs and appends them without recompressing existing samples.
+    /// </summary>
     public static async Task<FinalBankFiles> AppendFinalBanksFromWavFolder(
         string existingIcbPath,
         string existingIsbPath,
@@ -418,6 +443,7 @@ public static partial class ISACTBankBuilder
         Directory.CreateDirectory(stagingDirectory);
         try
         {
+            // Only the additions pass through BankBuilder; existing Ogg payloads are copied unchanged.
             FinalBankFiles compiledAdditions = await BuildFinalBanksFromWavFolder(
                 wavFolderPath,
                 stagingDirectory,
@@ -430,6 +456,7 @@ public static partial class ISACTBankBuilder
                 Path.GetFileNameWithoutExtension(existingIsbPath),
                 authoringMode).ConfigureAwait(false);
 
+            // Parse the existing final banks and the newly compressed additions as separate pairs.
             ISACTBankPair existing;
             using (var icbStream = File.OpenRead(existingIcbPath))
             using (var isbStream = File.OpenRead(existingIsbPath))
@@ -452,10 +479,12 @@ public static partial class ISACTBankBuilder
                 };
             }
 
+            // AppendCompiledBanks rebases resource indices and rebuilds the ICB content index.
             int existingSampleCount = GetNextResourceIndex(GetObjects(existing.ISBBank, "samp"));
             int existingEventCount = GetObjects(existing.ICBBank, "snde").Count;
             AppendCompiledBanks(existing, additions);
 
+            // Write to staging first so invalid output cannot overwrite a usable bank pair.
             Directory.CreateDirectory(outputDirectory);
             string outputIcbPath = Path.Combine(outputDirectory, Path.GetFileName(existingIcbPath));
             string outputIsbPath = Path.Combine(outputDirectory, Path.GetFileName(existingIsbPath));
@@ -466,13 +495,15 @@ public static partial class ISACTBankBuilder
             using (var stream = File.Create(temporaryIsbPath))
                 existing.ISBBank.Write(stream);
 
+            // Publish the pair only after its event count, compression, and size have been validated.
             ValidateBuiltBanks(temporaryIcbPath, temporaryIsbPath,
                 existingEventCount + compiledAdditions.EventMappings.Count, expectedSoundQueue: false);
             File.Move(temporaryIcbPath, outputIcbPath, overwrite: true);
             File.Move(temporaryIsbPath, outputIsbPath, overwrite: true);
 
+            // Return indices in the merged bank rather than the temporary additions bank.
             var rebasedMappings = compiledAdditions.EventMappings
-                .Select(mapping => mapping with { SampleIndex = checked(mapping.SampleIndex + existingSampleCount) })
+                .Select(mapping => mapping with { SampleIndex = mapping.SampleIndex + existingSampleCount })
                 .ToList();
             return new FinalBankFiles(
                 outputIcbPath,
@@ -494,7 +525,9 @@ public static partial class ISACTBankBuilder
         }
     }
 
-    // Compiles and replaces one ISB sample.
+    /// <summary>
+    /// Compiles a WAV and replaces one sample in a final ISB without changing its index or title.
+    /// </summary>
     public static async Task<SampleReplacementResult> ReplaceFinalBankSampleFromWave(
         string existingIsbPath,
         int sampleIndex,
@@ -518,6 +551,7 @@ public static partial class ISACTBankBuilder
         Directory.CreateDirectory(wavDirectory);
         try
         {
+            // Preserve the source bank's packet duration unless the caller explicitly overrides it.
             ISACTBank existing;
             using (var stream = File.OpenRead(existingIsbPath))
                 existing = new ISACTBank(stream);
@@ -525,12 +559,15 @@ public static partial class ISACTBankBuilder
                 ?? existing.BankChunks.OfType<IntBankChunk>().FirstOrDefault(chunk => chunk.ChunkName == "stri")?.Value
                 ?? 2500;
 
+            // A one-sample temporary bank lets BankBuilder produce the exact final sample metadata and payload.
             string stagedWave = Path.Combine(wavDirectory, "replacement_1.wav");
             File.Copy(replacementWavPath, stagedWave);
             string bankName = Path.GetFileNameWithoutExtension(existingIsbPath);
             FinalBankFiles compiled = await BuildFinalBanksFromWavFolder(
                 wavDirectory, compiledDirectory, bankName, bankBuilderPath,
                 packetMilliseconds, compressionQuality, timeout, cancellationToken).ConfigureAwait(false);
+
+            // Transfer the compiled sample payload while retaining the selected sample's index and title.
             ISACTBank replacementBank;
             using (var stream = File.OpenRead(compiled.ISBPath))
                 replacementBank = new ISACTBank(stream);
@@ -539,6 +576,7 @@ public static partial class ISACTBankBuilder
                 .Single(sample => GetRequiredIndex(sample).Value == sampleIndex).TitleInfo.Value;
             ReplaceCompiledSample(existing, sampleIndex, replacement);
 
+            // Validate a staged bank before replacing or creating the requested output file.
             string outputDirectory = Path.GetDirectoryName(Path.GetFullPath(outputIsbPath))!;
             Directory.CreateDirectory(outputDirectory);
             string temporaryOutput = Path.Combine(stagingDirectory, $"updated_{Guid.NewGuid():N}.isb");
@@ -559,6 +597,7 @@ public static partial class ISACTBankBuilder
         }
     }
 
+    // Serializes the minimal object layout emitted by ISACT Production Studio.
     private static ISACTBank CreateSampleBank(string bankName, IReadOnlyList<WaveSample> samples, int packetMilliseconds)
     {
         var bank = new ISACTBank(ISACTBankType.ISB);
@@ -679,6 +718,7 @@ public static partial class ISACTBankBuilder
 
         byte[] content = new byte[eventCount * 8];
         uint soundEventType = BinaryPrimitives.ReadUInt32LittleEndian("snde"u8);
+        // Queue content is stored as repeated object-type and resource-index pairs.
         for (int index = 0; index < eventCount; index++)
         {
             BinaryPrimitives.WriteUInt32LittleEndian(content.AsSpan(index * 8), soundEventType);
@@ -751,7 +791,7 @@ public static partial class ISACTBankBuilder
             if (localSampleIndex >= addedSampleCount)
                 throw new InvalidDataException(
                     $"Sound event '{soundEvent.TitleInfo?.Value}' references missing appended sample {localSampleIndex}.");
-            uint rebasedIndex = checked((uint)sampleBase + localSampleIndex);
+            uint rebasedIndex = (uint)sampleBase + localSampleIndex;
             track.BufferIndex = (track.BufferIndex & 0xFFFF0000) | rebasedIndex;
         }
     }
@@ -851,6 +891,7 @@ public static partial class ISACTBankBuilder
             return namedMappings;
         }
 
+        // Conversations require both gendered events; a single WAV is shared when no pair is supplied.
         var mappings = new List<EventMapping>();
         foreach (var group in samples.GroupBy(sample => sample.LineId).OrderBy(group => group.Key))
         {
@@ -947,6 +988,7 @@ public static partial class ISACTBankBuilder
         ushort blockAlign = 0;
         ushort bitsPerSample = 0;
         byte[] pcmData = null;
+        // RIFF chunks may appear in any order and are padded to even byte boundaries.
         while (stream.Position + 8 <= stream.Length)
         {
             string chunkName = ReadFourCC(reader);
@@ -1075,6 +1117,7 @@ public static partial class ISACTBankBuilder
         }
     }
 
+    // Reject partial or structurally invalid BankBuilder output before it reaches a package or DLC.
     private static void ValidateBuiltBanks(
         string icbPath, string isbPath, int expectedEventCount, bool expectedSoundQueue)
     {
@@ -1099,6 +1142,11 @@ public static partial class ISACTBankBuilder
 
     private static void ValidateFinalIsb(string isbPath)
     {
+        long fileSize = new FileInfo(isbPath).Length;
+        if (fileSize > MaximumFinalIsbSize)
+            throw new InvalidDataException(
+                $"The final ISB is {fileSize:N0} bytes. LE1 sample banks cannot exceed {MaximumFinalIsbSize:N0} bytes because the game uses 32-bit file offsets.");
+
         using var isbStream = File.OpenRead(isbPath);
         var isb = new ISACTBank(isbStream);
         if (isb.BankType != ISACTBankType.ISB)

--- a/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTBankBuilder.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTBankBuilder.cs
@@ -1,0 +1,1145 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LegendaryExplorerCore.Sound.ISACT;
+
+// Builds LE1 ISACT content and sample banks from PCM WAV files.
+public static partial class ISACTBankBuilder
+{
+    public enum AuthoringMode
+    {
+        Conversation,
+        Codex,
+        Soundset,
+        Music
+    }
+
+    private const int InvalidResourceIndex = int.MinValue;
+    private const int DefaultTimeCode = 0x00190028;
+    private const int DefaultTempo = 500000;
+    private const int DefaultTimeSignature = 0x00040004;
+    private const int DefaultSection = unchecked((int)0xE0000000);
+    private const int ContentIndexEntriesPerPage = 50;
+
+    // Describes an event-to-sample link created from the WAV filenames.
+    public sealed record EventMapping(string EventName, string SampleFileName, int SampleIndex);
+
+    // Source banks and their event mappings.
+    public sealed record SourceBankResult(ISACTBankPair Banks, IReadOnlyList<EventMapping> EventMappings);
+
+    // Paths written by WriteSourceBanksFromWavFolder.
+    public sealed record SourceBankFiles(string ICBPath, string ISBPath, IReadOnlyList<EventMapping> EventMappings);
+
+    // Final Ogg Vorbis banks produced by BankBuilder.
+    public sealed record FinalBankFiles(
+        string ICBPath,
+        string ISBPath,
+        string BuilderLog,
+        IReadOnlyList<EventMapping> EventMappings);
+
+    public sealed record SampleReplacementResult(
+        string ISBPath,
+        string BuilderLog,
+        int SampleIndex,
+        string SampleName);
+
+    // Appends compiled samples and events without recompressing existing samples.
+    public static ISACTBankPair AppendCompiledBanks(ISACTBankPair existing, ISACTBankPair additions)
+    {
+        ArgumentNullException.ThrowIfNull(existing);
+        ArgumentNullException.ThrowIfNull(additions);
+        ValidateBankPair(existing, nameof(existing));
+        ValidateBankPair(additions, nameof(additions));
+
+        List<ISACTListBankChunk> existingSamples = GetObjects(existing.ISBBank, "samp");
+        List<ISACTListBankChunk> addedSamples = GetObjects(additions.ISBBank, "samp");
+        List<ISACTListBankChunk> existingEvents = GetObjects(existing.ICBBank, "snde");
+        List<ISACTListBankChunk> addedEvents = GetObjects(additions.ICBBank, "snde");
+
+        EnsureUniqueTitles(existingSamples, addedSamples, "sample");
+        EnsureUniqueTitles(existingEvents, addedEvents, "sound event");
+        int sampleBase = GetNextResourceIndex(existingSamples);
+        int eventBase = GetNextResourceIndex(existingEvents);
+        if (sampleBase + addedSamples.Count > ushort.MaxValue)
+            throw new InvalidDataException("The merged ISACT sample bank would exceed 65,535 addressable samples.");
+
+        foreach (ISACTListBankChunk sample in addedSamples)
+        {
+            IntBankChunk index = GetRequiredIndex(sample);
+            index.Value = checked(index.Value + sampleBase);
+            existing.ISBBank.BankChunks.Add(sample);
+        }
+
+        foreach (ISACTListBankChunk soundEvent in addedEvents)
+        {
+            IntBankChunk index = GetRequiredIndex(soundEvent);
+            index.Value = checked(index.Value + eventBase);
+            RebaseSoundEventSamples(soundEvent, sampleBase, addedSamples.Count);
+            existing.ICBBank.BankChunks.Add(soundEvent);
+        }
+
+        ContentIndexBankChunk contentIndex = existing.ICBBank.BankChunks
+            .OfType<ContentIndexBankChunk>()
+            .SingleOrDefault()
+            ?? throw new InvalidDataException("The existing ICB does not contain a content index.");
+        IReadOnlyList<IndexEntry> existingIndexEntries = contentIndex.IndexPages
+            .SelectMany(page => page.IndexEntries)
+            .ToList();
+        var mergedIndexEntries = existingIndexEntries
+            .Concat(addedEvents.Select((soundEvent, localIndex) => new IndexEntry
+            {
+                Title = soundEvent.TitleInfo.Value,
+                ObjectType = "snde",
+                ObjectIndex = checked((uint)(eventBase + localIndex))
+            }))
+            .ToArray();
+        contentIndex.IndexPages = CreateIndexPages(mergedIndexEntries);
+        return existing;
+    }
+
+    // Replaces one compiled sample while preserving its resource index and title.
+    public static void ReplaceCompiledSample(
+        ISACTBank existingIsb,
+        int sampleIndex,
+        ISACTListBankChunk compiledReplacement)
+    {
+        ArgumentNullException.ThrowIfNull(existingIsb);
+        ArgumentNullException.ThrowIfNull(compiledReplacement);
+        if (existingIsb.BankType != ISACTBankType.ISB)
+            throw new ArgumentException("The existing bank must be an ISB.", nameof(existingIsb));
+        if (compiledReplacement.ObjectType != "samp")
+            throw new ArgumentException("The replacement object must be an ISACT sample.", nameof(compiledReplacement));
+
+        ISACTListBankChunk target = GetObjects(existingIsb, "samp")
+            .SingleOrDefault(sample => GetRequiredIndex(sample).Value == sampleIndex)
+            ?? throw new InvalidDataException($"The ISB does not contain sample index {sampleIndex}.");
+        string originalTitle = target.TitleInfo?.Value
+            ?? throw new InvalidDataException($"ISACT sample {sampleIndex} has no title.");
+        int bankChunkIndex = existingIsb.BankChunks.IndexOf(target);
+        if (bankChunkIndex < 0)
+            throw new InvalidDataException($"ISACT sample {sampleIndex} is not a top-level bank object.");
+
+        GetRequiredIndex(compiledReplacement).Value = sampleIndex;
+        if (compiledReplacement.TitleInfo is null)
+            throw new InvalidDataException("The compiled replacement sample has no title.");
+        compiledReplacement.TitleInfo.RawData = Encoding.Unicode.GetBytes(originalTitle + '\0');
+
+        // Preserve the original authoring path.
+        BankChunk originalPath = target.GetChunk("path");
+        BankChunk replacementPath = compiledReplacement.GetChunk("path");
+        if (originalPath is not null && replacementPath is not null)
+            replacementPath.RawData = originalPath.RawData?.ToArray();
+
+        existingIsb.BankChunks[bankChunkIndex] = compiledReplacement;
+    }
+
+    private enum DialogueGender
+    {
+        Shared,
+        Female,
+        Male
+    }
+
+    private sealed record WaveSample(
+        string FilePath,
+        string FileName,
+        ulong LineId,
+        DialogueGender Gender,
+        int SampleRate,
+        ushort BitsPerSample,
+        ushort Channels,
+        ushort BlockAlign,
+        byte[] PCMData);
+
+    private static readonly IReadOnlyDictionary<string, string> SoundsetEventNames =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["acl"] = "Allclear", ["alr"] = "Alert", ["atg"] = "AttackGrunt",
+            ["bfa"] = "BuffActivated", ["dth"] = "DeathCry", ["gcf"] = "GiveCommandFollow",
+            ["hpn"] = "HoldingPosition", ["hsq"] = "HealingSquad", ["idl"] = "Idle",
+            ["igr"] = "IncomingGrenade", ["jmp"] = "Jump", ["lkf"] = "LOSunavailable",
+            ["lnd"] = "Land", ["lse"] = "LOSestablished", ["lwh"] = "LowHealth",
+            ["mov"] = "Move", ["mtf"] = "MoveToFailure", ["mts"] = "MoveToSuccess",
+            ["pae"] = "PerceptionAttackedByEnemy", ["phe"] = "PerceptionHearEnemy",
+            ["png"] = "PainGrunt", ["prc"] = "PlayerRecovery",
+            ["shd"] = "ShieldsDown", ["smv"] = "StartMoveToConfirmation",
+            ["tbd"] = "TechBeaconDeployed", ["tdr"] = "TacticalDeathRecovery",
+            ["tgd"] = "TargetDown", ["tgr"] = "ThrowGrenade", ["vdm"] = "VehicleDamaged",
+            ["vsd"] = "VehicleShieldsDown"
+        };
+
+    // Creates BankBuilder-ready PCM banks from a WAV folder.
+    public static SourceBankResult CreateSourceBanksFromWavFolder(
+        string wavFolderPath,
+        string bankName,
+        int streamPacketMilliseconds = 2500,
+        string sampleBankName = null,
+        AuthoringMode authoringMode = AuthoringMode.Conversation,
+        bool createLoopingMusicQueue = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(wavFolderPath);
+        ValidateBankName(bankName);
+        sampleBankName ??= bankName;
+        ValidateBankName(sampleBankName);
+        if (authoringMode == AuthoringMode.Music &&
+            !bankName.StartsWith("mus_", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidDataException("Music bank names must begin with 'mus_'.");
+
+        if (!Directory.Exists(wavFolderPath))
+            throw new DirectoryNotFoundException($"WAV folder does not exist: {wavFolderPath}");
+        if (streamPacketMilliseconds < 0)
+            throw new ArgumentOutOfRangeException(nameof(streamPacketMilliseconds), "Packet duration cannot be negative.");
+
+        var wavPaths = Directory.EnumerateFiles(wavFolderPath, "*.wav", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => Path.GetFileName(path), StringComparer.OrdinalIgnoreCase)
+            .ThenBy(path => Path.GetFileName(path), StringComparer.Ordinal)
+            .ToList();
+        if (wavPaths.Count == 0)
+            throw new InvalidDataException($"No WAV files were found in: {wavFolderPath}");
+        if (wavPaths.Count > ushort.MaxValue)
+            throw new InvalidDataException("An ISACT sample bank cannot contain more than 65,535 addressable samples.");
+
+        var samples = wavPaths.Select(path => ReadWaveSample(path, authoringMode)).ToList();
+        if (authoringMode == AuthoringMode.Conversation)
+            ValidateLineInputs(samples);
+
+        var sampleIndexes = samples
+            .Select((sample, index) => (sample.FilePath, index))
+            .ToDictionary(item => item.FilePath, item => item.index, StringComparer.OrdinalIgnoreCase);
+        var eventMappings = CreateEventMappings(samples, sampleIndexes, authoringMode);
+
+        var isb = CreateSampleBank(sampleBankName, samples, streamPacketMilliseconds);
+        if (createLoopingMusicQueue && authoringMode != AuthoringMode.Music)
+            throw new ArgumentException("Looping Sound Queues are only supported for music authoring.", nameof(createLoopingMusicQueue));
+        var icb = CreateContentBank(bankName, eventMappings, createLoopingMusicQueue);
+        return new SourceBankResult(new ISACTBankPair { ICBBank = icb, ISBBank = isb }, eventMappings);
+    }
+
+    // Writes PCM ICB and ISB files for BankBuilder.
+    public static SourceBankFiles WriteSourceBanksFromWavFolder(
+        string wavFolderPath,
+        string outputDirectory,
+        string bankName,
+        int streamPacketMilliseconds = 2500,
+        string sampleBankName = null,
+        AuthoringMode authoringMode = AuthoringMode.Conversation,
+        bool createLoopingMusicQueue = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectory);
+        sampleBankName ??= bankName;
+        var result = CreateSourceBanksFromWavFolder(
+            wavFolderPath, bankName, streamPacketMilliseconds, sampleBankName, authoringMode,
+            createLoopingMusicQueue);
+        Directory.CreateDirectory(outputDirectory);
+
+        string icbPath = Path.Combine(outputDirectory, $"{bankName}.icb");
+        string isbPath = Path.Combine(outputDirectory, $"{sampleBankName}.isb");
+        using (var stream = File.Create(icbPath))
+            result.Banks.ICBBank.Write(stream);
+        using (var stream = File.Create(isbPath))
+            result.Banks.ISBBank.Write(stream);
+
+        return new SourceBankFiles(icbPath, isbPath, result.EventMappings);
+    }
+
+    // Builds and validates final banks with BankBuilder.
+    public static async Task<FinalBankFiles> BuildFinalBanksFromWavFolder(
+        string wavFolderPath,
+        string outputDirectory,
+        string bankName,
+        string bankBuilderPath,
+        int streamPacketMilliseconds = 2500,
+        float compressionQuality = 0.8f,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default,
+        string sampleBankName = null,
+        AuthoringMode authoringMode = AuthoringMode.Conversation,
+        bool createLoopingMusicQueue = false)
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("The official ISACT BankBuilder is a Windows executable.");
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(bankBuilderPath);
+        sampleBankName ??= bankName;
+        ValidateBankName(sampleBankName);
+        if (compressionQuality is < 0 or > 1)
+            throw new ArgumentOutOfRangeException(nameof(compressionQuality), "Compression quality must be between 0 and 1.");
+
+        string bankBuilderExe = ResolveBankBuilderExecutable(bankBuilderPath);
+        string stagingRoot = Path.Combine(Path.GetTempPath(), $"LEX_ISACTBankBuilder_{Guid.NewGuid():N}");
+        string toolDirectory = Path.Combine(stagingRoot, "tool");
+        string sourceDirectory = Path.Combine(stagingRoot, "source");
+        string builtDirectory = Path.Combine(stagingRoot, "built");
+        Directory.CreateDirectory(toolDirectory);
+        Directory.CreateDirectory(sourceDirectory);
+        Directory.CreateDirectory(builtDirectory);
+
+        string builderLog = string.Empty;
+        try
+        {
+            string stagedBuilder = Path.Combine(toolDirectory, "BankBuilder.exe");
+            File.Copy(bankBuilderExe, stagedBuilder);
+            foreach (string codecName in new[] { "ogg.dll", "vorbis.dll", "vorbisfile.dll" })
+            {
+                string codecPath = ResolveBankBuilderDependency(bankBuilderExe, codecName);
+                File.Copy(codecPath, Path.Combine(toolDirectory, codecName));
+            }
+
+            SourceBankFiles sourceFiles = WriteSourceBanksFromWavFolder(
+                wavFolderPath, sourceDirectory, bankName, streamPacketMilliseconds, sampleBankName,
+                authoringMode, createLoopingMusicQueue);
+            string quality = compressionQuality.ToString("0.0###", CultureInfo.InvariantCulture);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = stagedBuilder,
+                // BankBuilder's parser expects the value to be concatenated to the switch.
+                Arguments = $"-i\"{sourceDirectory}\" -o\"{builtDirectory}\" -cOGGVORBIS -pWindows -q{quality}",
+                WorkingDirectory = toolDirectory,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("BankBuilder could not be started.");
+            Task<string> standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            Task<string> standardError = process.StandardError.ReadToEndAsync(cancellationToken);
+            string builderLogPath = Path.Combine(toolDirectory, "BuilderLog.txt");
+            bool completedFromLog = false;
+            var elapsed = Stopwatch.StartNew();
+            try
+            {
+                while (!process.HasExited)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (elapsed.Elapsed > (timeout ?? TimeSpan.FromMinutes(10)))
+                        throw new TimeoutException("ISACT BankBuilder did not finish within the allowed time.");
+
+                    builderLog = TryReadBuilderLog(builderLogPath);
+                    if (HasBuilderCompletionSummary(builderLog))
+                    {
+                        completedFromLog = true;
+                        break;
+                    }
+                    await Task.Delay(200, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                    await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+                }
+                throw;
+            }
+
+            // BankBuilder can remain idle after writing its completion summary.
+            if (completedFromLog && !process.HasExited)
+                process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+
+            string stdout = await standardOutput.ConfigureAwait(false);
+            string stderr = await standardError.ConfigureAwait(false);
+            builderLog = TryReadBuilderLog(builderLogPath);
+
+            if (!completedFromLog && process.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"BankBuilder exited with code {process.ExitCode}.\n{stdout}\n{stderr}\n{builderLog}".Trim());
+            }
+            if (ContainsBuilderFailure(builderLog))
+                throw new InvalidOperationException($"BankBuilder reported a warning or error:\n{builderLog}");
+
+            string builtICB = Path.Combine(builtDirectory, Path.GetFileName(sourceFiles.ICBPath));
+            string builtISB = Path.Combine(builtDirectory, Path.GetFileName(sourceFiles.ISBPath));
+            ValidateBuiltBanks(
+                builtICB, builtISB, sourceFiles.EventMappings.Count, createLoopingMusicQueue);
+
+            Directory.CreateDirectory(outputDirectory);
+            string finalICB = Path.Combine(outputDirectory, $"{bankName}.icb");
+            string finalISB = Path.Combine(outputDirectory, $"{sampleBankName}.isb");
+            File.Copy(builtICB, finalICB, overwrite: true);
+            File.Copy(builtISB, finalISB, overwrite: true);
+            return new FinalBankFiles(finalICB, finalISB, builderLog, sourceFiles.EventMappings);
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot))
+            {
+                try
+                {
+                    Directory.Delete(stagingRoot, recursive: true);
+                }
+                catch (IOException)
+                {
+                    // Redirected handles may be released after process exit.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Preserve the build result.
+                }
+            }
+        }
+    }
+
+    // Compiles and appends new WAVs without recompressing existing samples.
+    public static async Task<FinalBankFiles> AppendFinalBanksFromWavFolder(
+        string existingIcbPath,
+        string existingIsbPath,
+        string wavFolderPath,
+        string outputDirectory,
+        string bankBuilderPath,
+        int streamPacketMilliseconds = 2500,
+        float compressionQuality = 0.8f,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default,
+        AuthoringMode authoringMode = AuthoringMode.Conversation)
+    {
+        if (!File.Exists(existingIcbPath))
+            throw new FileNotFoundException("Existing ICB was not found.", existingIcbPath);
+        if (!File.Exists(existingIsbPath))
+            throw new FileNotFoundException("Existing ISB was not found.", existingIsbPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectory);
+
+        string bankName = Path.GetFileNameWithoutExtension(existingIcbPath);
+        string stagingDirectory = Path.Combine(Path.GetTempPath(), $"LEX_ISACTAppend_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(stagingDirectory);
+        try
+        {
+            FinalBankFiles compiledAdditions = await BuildFinalBanksFromWavFolder(
+                wavFolderPath,
+                stagingDirectory,
+                bankName,
+                bankBuilderPath,
+                streamPacketMilliseconds,
+                compressionQuality,
+                timeout,
+                cancellationToken,
+                Path.GetFileNameWithoutExtension(existingIsbPath),
+                authoringMode).ConfigureAwait(false);
+
+            ISACTBankPair existing;
+            using (var icbStream = File.OpenRead(existingIcbPath))
+            using (var isbStream = File.OpenRead(existingIsbPath))
+            {
+                existing = new ISACTBankPair
+                {
+                    ICBBank = new ISACTBank(icbStream),
+                    ISBBank = new ISACTBank(isbStream)
+                };
+            }
+
+            ISACTBankPair additions;
+            using (var icbStream = File.OpenRead(compiledAdditions.ICBPath))
+            using (var isbStream = File.OpenRead(compiledAdditions.ISBPath))
+            {
+                additions = new ISACTBankPair
+                {
+                    ICBBank = new ISACTBank(icbStream),
+                    ISBBank = new ISACTBank(isbStream)
+                };
+            }
+
+            int existingSampleCount = GetNextResourceIndex(GetObjects(existing.ISBBank, "samp"));
+            int existingEventCount = GetObjects(existing.ICBBank, "snde").Count;
+            AppendCompiledBanks(existing, additions);
+
+            Directory.CreateDirectory(outputDirectory);
+            string outputIcbPath = Path.Combine(outputDirectory, Path.GetFileName(existingIcbPath));
+            string outputIsbPath = Path.Combine(outputDirectory, Path.GetFileName(existingIsbPath));
+            string temporaryIcbPath = Path.Combine(stagingDirectory, $"merged_{Guid.NewGuid():N}.icb");
+            string temporaryIsbPath = Path.Combine(stagingDirectory, $"merged_{Guid.NewGuid():N}.isb");
+            using (var stream = File.Create(temporaryIcbPath))
+                existing.ICBBank.Write(stream);
+            using (var stream = File.Create(temporaryIsbPath))
+                existing.ISBBank.Write(stream);
+
+            ValidateBuiltBanks(temporaryIcbPath, temporaryIsbPath,
+                existingEventCount + compiledAdditions.EventMappings.Count, expectedSoundQueue: false);
+            File.Move(temporaryIcbPath, outputIcbPath, overwrite: true);
+            File.Move(temporaryIsbPath, outputIsbPath, overwrite: true);
+
+            var rebasedMappings = compiledAdditions.EventMappings
+                .Select(mapping => mapping with { SampleIndex = checked(mapping.SampleIndex + existingSampleCount) })
+                .ToList();
+            return new FinalBankFiles(
+                outputIcbPath,
+                outputIsbPath,
+                compiledAdditions.BuilderLog,
+                rebasedMappings);
+        }
+        finally
+        {
+            if (Directory.Exists(stagingDirectory))
+            {
+                try
+                {
+                    Directory.Delete(stagingDirectory, recursive: true);
+                }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+    }
+
+    // Compiles and replaces one ISB sample.
+    public static async Task<SampleReplacementResult> ReplaceFinalBankSampleFromWave(
+        string existingIsbPath,
+        int sampleIndex,
+        string replacementWavPath,
+        string outputIsbPath,
+        string bankBuilderPath,
+        int? streamPacketMilliseconds = null,
+        float compressionQuality = 0.8f,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(existingIsbPath))
+            throw new FileNotFoundException("Existing ISB was not found.", existingIsbPath);
+        if (!File.Exists(replacementWavPath))
+            throw new FileNotFoundException("Replacement WAV was not found.", replacementWavPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputIsbPath);
+
+        string stagingDirectory = Path.Combine(Path.GetTempPath(), $"LEX_ISACTReplace_{Guid.NewGuid():N}");
+        string wavDirectory = Path.Combine(stagingDirectory, "wav");
+        string compiledDirectory = Path.Combine(stagingDirectory, "compiled");
+        Directory.CreateDirectory(wavDirectory);
+        try
+        {
+            ISACTBank existing;
+            using (var stream = File.OpenRead(existingIsbPath))
+                existing = new ISACTBank(stream);
+            int packetMilliseconds = streamPacketMilliseconds
+                ?? existing.BankChunks.OfType<IntBankChunk>().FirstOrDefault(chunk => chunk.ChunkName == "stri")?.Value
+                ?? 2500;
+
+            string stagedWave = Path.Combine(wavDirectory, "replacement_1.wav");
+            File.Copy(replacementWavPath, stagedWave);
+            string bankName = Path.GetFileNameWithoutExtension(existingIsbPath);
+            FinalBankFiles compiled = await BuildFinalBanksFromWavFolder(
+                wavDirectory, compiledDirectory, bankName, bankBuilderPath,
+                packetMilliseconds, compressionQuality, timeout, cancellationToken).ConfigureAwait(false);
+            ISACTBank replacementBank;
+            using (var stream = File.OpenRead(compiled.ISBPath))
+                replacementBank = new ISACTBank(stream);
+            ISACTListBankChunk replacement = GetObjects(replacementBank, "samp").Single();
+            string sampleName = GetObjects(existing, "samp")
+                .Single(sample => GetRequiredIndex(sample).Value == sampleIndex).TitleInfo.Value;
+            ReplaceCompiledSample(existing, sampleIndex, replacement);
+
+            string outputDirectory = Path.GetDirectoryName(Path.GetFullPath(outputIsbPath))!;
+            Directory.CreateDirectory(outputDirectory);
+            string temporaryOutput = Path.Combine(stagingDirectory, $"updated_{Guid.NewGuid():N}.isb");
+            using (var stream = File.Create(temporaryOutput))
+                existing.Write(stream);
+            ValidateFinalIsb(temporaryOutput);
+            File.Move(temporaryOutput, outputIsbPath, overwrite: true);
+            return new SampleReplacementResult(outputIsbPath, compiled.BuilderLog, sampleIndex, sampleName);
+        }
+        finally
+        {
+            if (Directory.Exists(stagingDirectory))
+            {
+                try { Directory.Delete(stagingDirectory, true); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+    }
+
+    private static ISACTBank CreateSampleBank(string bankName, IReadOnlyList<WaveSample> samples, int packetMilliseconds)
+    {
+        var bank = new ISACTBank(ISACTBankType.ISB);
+        bank.BankChunks.AddRange(CreateCommonObjectChunks(
+            title: $"{bankName}.isb",
+            resourceIndex: 0,
+            globalEffectIndex: InvalidResourceIndex,
+            trackCount: 1,
+            status: 32));
+        bank.BankChunks.Add(IntChunk("stri", packetMilliseconds));
+        bank.BankChunks.Add(IntChunk("msti", 0));
+
+        for (int index = 0; index < samples.Count; index++)
+            bank.BankChunks.Add(CreateSampleObject(samples[index], index));
+        return bank;
+    }
+
+    private static ISACTListBankChunk CreateSampleObject(WaveSample sample, int sampleIndex)
+    {
+        long frameCount = sample.PCMData.LongLength / sample.BlockAlign;
+        int durationMilliseconds = frameCount == 0
+            ? 0
+            : checked((int)(((frameCount - 1) * 1000L) / sample.SampleRate));
+
+        var chunks = CreateCommonObjectChunks(
+            title: sample.FileName,
+            resourceIndex: sampleIndex,
+            globalEffectIndex: InvalidResourceIndex,
+            trackCount: 1,
+            status: 0);
+        chunks.Add(new SampleInfoBankChunk
+        {
+            ChunkName = SampleInfoBankChunk.FixedChunkTitle,
+            BufferOffset = 0,
+            TimeLength = durationMilliseconds,
+            SamplesPerSecond = sample.SampleRate,
+            ByteLength = sample.PCMData.Length,
+            BitsPerSample = sample.BitsPerSample
+        });
+        chunks.Add(IntChunk("s3di", InvalidResourceIndex));
+        chunks.Add(new ChannelBankChunk
+        {
+            ChunkName = ChannelBankChunk.FixedChunkTitle,
+            ChannelCount = sample.Channels
+        });
+        chunks.Add(IntChunk("prel", 0));
+        chunks.Add(new CompressionInfoBankChunk
+        {
+            ChunkName = CompressionInfoBankChunk.FixedChunkTitle,
+            CurrentFormat = CompressionInfoBankChunk.ISACTCompressionFormat.PCM,
+            TargetFormat = CompressionInfoBankChunk.ISACTCompressionFormat.PCM,
+            TotalSize = 0,
+            PacketSize = 0,
+            CompressionRatio = 0,
+            CompressionQuality = 0.4f
+        });
+        chunks.Add(IntChunk("chfl", GetChannelFlags(sample.Channels)));
+        chunks.Add(UnicodeChunk("path", sample.FilePath));
+        chunks.Add(RawChunk(DataBankChunk.FixedChunkTitle, sample.PCMData));
+        return new ISACTListBankChunk("samp", chunks);
+    }
+
+    private static ISACTBank CreateContentBank(
+        string bankName, IReadOnlyList<EventMapping> eventMappings, bool createLoopingQueue)
+    {
+        var bank = new ISACTBank(ISACTBankType.ICB);
+        bank.BankChunks.AddRange(CreateCommonObjectChunks(
+            title: $"{bankName}.icb",
+            resourceIndex: InvalidResourceIndex,
+            globalEffectIndex: InvalidResourceIndex,
+            trackCount: 1,
+            status: 32));
+        bank.BankChunks.Add(CreateContentIndex(eventMappings, createLoopingQueue ? bankName : null));
+        bank.BankChunks.Add(IntChunk("segv", 0));
+
+        for (int eventIndex = 0; eventIndex < eventMappings.Count; eventIndex++)
+            bank.BankChunks.Add(CreateSoundEvent(eventMappings[eventIndex], eventIndex));
+        if (createLoopingQueue)
+            bank.BankChunks.Add(CreateSoundQueue(bankName, eventMappings.Count));
+        return bank;
+    }
+
+    private static ContentIndexBankChunk CreateContentIndex(
+        IReadOnlyList<EventMapping> eventMappings, string queueName)
+    {
+        IEnumerable<IndexEntry> entries = eventMappings.Select((mapping, index) => new IndexEntry
+        {
+            Title = mapping.EventName,
+            ObjectType = "snde",
+            ObjectIndex = (uint)index
+        });
+        if (queueName is not null)
+        {
+            entries = entries.Append(new IndexEntry
+            {
+                Title = queueName,
+                ObjectType = "sdqu",
+                ObjectIndex = 0
+            });
+        }
+
+        return new ContentIndexBankChunk
+        {
+            ChunkName = ContentIndexBankChunk.FixedChunkTitle,
+            IndexPages = CreateIndexPages(entries.ToArray())
+        };
+    }
+
+    private static ISACTListBankChunk CreateSoundQueue(string queueName, int eventCount)
+    {
+        var chunks = CreateCommonObjectChunks(
+            title: queueName,
+            resourceIndex: 0,
+            globalEffectIndex: -1,
+            trackCount: 1,
+            status: 0);
+        chunks.Add(RawInt32Chunk("qinf", eventCount, 0, eventCount - 1, 0));
+
+        byte[] content = new byte[eventCount * 8];
+        uint soundEventType = BinaryPrimitives.ReadUInt32LittleEndian("snde"u8);
+        for (int index = 0; index < eventCount; index++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(content.AsSpan(index * 8), soundEventType);
+            BinaryPrimitives.WriteUInt32LittleEndian(content.AsSpan(index * 8 + 4), (uint)index);
+        }
+        chunks.Add(RawChunk("qcnt", content));
+        return new ISACTListBankChunk("sdqu", chunks);
+    }
+
+    private static List<IndexPage> CreateIndexPages(IReadOnlyList<IndexEntry> entries)
+    {
+        var pages = new List<IndexPage>();
+        for (int start = 0; start < entries.Count; start += ContentIndexEntriesPerPage)
+        {
+            IndexEntry[] pageEntries = entries.Skip(start).Take(ContentIndexEntriesPerPage).ToArray();
+            pages.Add(new IndexPage
+            {
+                EntryCount = (uint)pageEntries.Length,
+                IndexEntries = pageEntries
+            });
+        }
+        return pages;
+    }
+
+    private static void ValidateBankPair(ISACTBankPair pair, string parameterName)
+    {
+        if (pair.ICBBank?.BankType != ISACTBankType.ICB || pair.ISBBank?.BankType != ISACTBankType.ISB)
+            throw new ArgumentException("The bank pair must contain an ICB and an ISB.", parameterName);
+    }
+
+    private static List<ISACTListBankChunk> GetObjects(ISACTBank bank, string objectType) =>
+        bank.BankChunks.OfType<ISACTListBankChunk>().Where(chunk => chunk.ObjectType == objectType).ToList();
+
+    private static void EnsureUniqueTitles(
+        IEnumerable<ISACTListBankChunk> existing,
+        IEnumerable<ISACTListBankChunk> additions,
+        string objectDescription)
+    {
+        var titles = new HashSet<string>(
+            existing.Select(chunk => chunk.TitleInfo?.Value ?? string.Empty),
+            StringComparer.OrdinalIgnoreCase);
+        foreach (ISACTListBankChunk addition in additions)
+        {
+            string title = addition.TitleInfo?.Value
+                ?? throw new InvalidDataException($"An appended {objectDescription} has no title.");
+            if (!titles.Add(title))
+                throw new InvalidDataException($"Cannot append duplicate {objectDescription} '{title}'.");
+        }
+    }
+
+    private static IntBankChunk GetRequiredIndex(ISACTListBankChunk chunk) =>
+        chunk.GetChunk("indx") as IntBankChunk
+        ?? throw new InvalidDataException($"ISACT {chunk.ObjectType} '{chunk.TitleInfo?.Value}' has no resource index.");
+
+    private static int GetNextResourceIndex(IReadOnlyCollection<ISACTListBankChunk> objects) =>
+        objects.Count == 0 ? 0 : checked(objects.Max(chunk => GetRequiredIndex(chunk).Value) + 1);
+
+    private static void RebaseSoundEventSamples(ISACTListBankChunk soundEvent, int sampleBase, int addedSampleCount)
+    {
+        IEnumerable<ISACTSoundTrack> tracks = soundEvent.GetChunk(SoundEventSoundTracks.FixedChunkTitle) switch
+        {
+            SoundEventSoundTracks standard => standard.SoundTracks,
+            _ when soundEvent.GetChunk(SoundEventSoundTracksFour.FixedChunkTitle) is SoundEventSoundTracksFour compact => compact.SoundTracks,
+            _ => throw new InvalidDataException($"Sound event '{soundEvent.TitleInfo?.Value}' has no supported sound tracks.")
+        };
+
+        foreach (ISACTSoundTrack track in tracks)
+        {
+            uint localSampleIndex = track.BufferIndex & 0xFFFF;
+            if (localSampleIndex >= addedSampleCount)
+                throw new InvalidDataException(
+                    $"Sound event '{soundEvent.TitleInfo?.Value}' references missing appended sample {localSampleIndex}.");
+            uint rebasedIndex = checked((uint)sampleBase + localSampleIndex);
+            track.BufferIndex = (track.BufferIndex & 0xFFFF0000) | rebasedIndex;
+        }
+    }
+
+    private static ISACTListBankChunk CreateSoundEvent(EventMapping mapping, int eventIndex)
+    {
+        var chunks = CreateCommonObjectChunks(
+            title: mapping.EventName,
+            resourceIndex: eventIndex,
+            globalEffectIndex: -1,
+            trackCount: 1,
+            status: 0);
+        chunks.Add(new SoundEventInfoBankChunk
+        {
+            ChunkName = SoundEventInfoBankChunk.FixedChunkTitle,
+            EventSelection = SoundEventInfoBankChunk.ISACTSEEventSelection.USE_EVS_CHANCE,
+            DefaultChance = 50,
+            EqualChance = 1,
+            Flags = 0,
+            ResetParamsOnLoop = 1,
+            ResetSampleOnLoop = 1
+        });
+        chunks.Add(new SoundEventSoundTracks
+        {
+            ChunkName = SoundEventSoundTracks.FixedChunkTitle,
+            SoundTracks = new List<ISACTSoundTrack> { CreateSoundTrack(mapping.SampleIndex) }
+        });
+        chunks.Add(RawChunk("silt", Array.Empty<byte>()));
+        return new ISACTListBankChunk("snde", chunks);
+    }
+
+    private static ISACTSoundTrack CreateSoundTrack(int sampleIndex) => new()
+    {
+        BufferIndex = 0x10000u | (uint)sampleIndex,
+        PathIndex = uint.MaxValue,
+        Order = 1,
+        Chance = 100,
+        Position = Vector3.Zero,
+        Orientation = new ISACTOrientation(),
+        Velocity = Vector3.Zero,
+        MinGain = 1,
+        MaxGain = 1,
+        MinPitch = 1,
+        MaxPitch = 1,
+        MinDirect = 1,
+        MaxDirect = 1,
+        MinDirectHF = 1,
+        MaxDirectHF = 1,
+        SendEnable = new int[4],
+        MinSend = new float[4],
+        MaxSend = new float[4],
+        MinSendHF = Enumerable.Repeat(1f, 4).ToArray(),
+        MaxSendHF = Enumerable.Repeat(1f, 4).ToArray(),
+        Flags = 0x3F
+    };
+
+    private static List<BankChunk> CreateCommonObjectChunks(
+        string title,
+        int resourceIndex,
+        int globalEffectIndex,
+        int trackCount,
+        int status)
+    {
+        return new List<BankChunk>
+        {
+            IntChunk("stat", status),
+            UnicodeChunk(TitleBankChunk.FixedChunkTitle, title),
+            IntChunk("indx", resourceIndex),
+            IntChunk("geix", globalEffectIndex),
+            IntChunk("trks", trackCount),
+            IntChunk("tmcd", DefaultTimeCode),
+            IntChunk("dtmp", DefaultTempo),
+            IntChunk("dtsg", DefaultTimeSignature),
+            IntChunk("dsec", DefaultSection),
+            RawInt32Chunk("sync", 0, 1),
+            IntChunk("loop", 0),
+            FloatChunk("gbst", 1),
+            RawInt32Chunk("cgvi", -1, -1, -1, -1, 0)
+        };
+    }
+
+    private static IReadOnlyList<EventMapping> CreateEventMappings(
+        IReadOnlyList<WaveSample> samples,
+        IReadOnlyDictionary<string, int> sampleIndexes,
+        AuthoringMode authoringMode)
+    {
+        if (authoringMode != AuthoringMode.Conversation)
+        {
+            var namedMappings = samples.Select(sample => new EventMapping(
+                GetNamedEventName(sample, authoringMode),
+                sample.FileName,
+                sampleIndexes[sample.FilePath])).ToList();
+            string duplicate = namedMappings.GroupBy(mapping => mapping.EventName, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault(group => group.Count() > 1)?.Key;
+            if (duplicate is not null)
+                throw new InvalidDataException($"Multiple WAV files produce the sound event '{duplicate}'.");
+            return namedMappings;
+        }
+
+        var mappings = new List<EventMapping>();
+        foreach (var group in samples.GroupBy(sample => sample.LineId).OrderBy(group => group.Key))
+        {
+            WaveSample shared = group.SingleOrDefault(sample => sample.Gender == DialogueGender.Shared);
+            WaveSample female = group.SingleOrDefault(sample => sample.Gender == DialogueGender.Female);
+            WaveSample male = group.SingleOrDefault(sample => sample.Gender == DialogueGender.Male);
+            WaveSample femaleSample = female ?? shared ?? male;
+            WaveSample maleSample = male ?? shared ?? female;
+            string eventBaseName = $"VO_{group.Key.ToString(CultureInfo.InvariantCulture)}";
+
+            mappings.Add(new EventMapping(eventBaseName, femaleSample.FileName, sampleIndexes[femaleSample.FilePath]));
+            mappings.Add(new EventMapping($"{eventBaseName}_M", maleSample.FileName, sampleIndexes[maleSample.FilePath]));
+        }
+        return mappings;
+    }
+
+    private static string GetNamedEventName(WaveSample sample, AuthoringMode authoringMode)
+    {
+        string fileBaseName = Path.GetFileNameWithoutExtension(sample.FileName);
+        if (authoringMode is AuthoringMode.Codex or AuthoringMode.Music)
+        {
+            if (authoringMode == AuthoringMode.Codex &&
+                !fileBaseName.StartsWith("vo_codex_", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidDataException($"Codex WAV names must begin with 'vo_codex_': {sample.FileName}");
+            return fileBaseName;
+        }
+
+        Match match = SoundsetFileNameRegex().Match(fileBaseName);
+        if (!match.Success)
+            throw new InvalidDataException(
+                $"Soundset WAV names must end in a supported three-character cue code and two-digit index: {sample.FileName}");
+        if (match.Groups["racialVariant"].Success)
+            return $"VO_SpecialAbilityRacial{match.Groups["racialVariant"].Value}_{match.Groups["index"].Value}";
+
+        string code = match.Groups["code"].Value;
+        if (!SoundsetEventNames.TryGetValue(code, out string eventName))
+            throw new InvalidDataException($"Unknown soundset cue code '{code}' in {sample.FileName}.");
+        return $"VO_{eventName}_{match.Groups["index"].Value}";
+    }
+
+    private static void ValidateLineInputs(IEnumerable<WaveSample> samples)
+    {
+        foreach (var group in samples.GroupBy(sample => sample.LineId))
+        {
+            foreach (var genderGroup in group.GroupBy(sample => sample.Gender))
+            {
+                if (genderGroup.Count() > 1)
+                {
+                    string files = string.Join(", ", genderGroup.Select(sample => sample.FileName));
+                    throw new InvalidDataException(
+                        $"Line {group.Key} has multiple {genderGroup.Key} WAV files: {files}");
+                }
+            }
+        }
+    }
+
+    private static WaveSample ReadWaveSample(string path, AuthoringMode authoringMode)
+    {
+        string fileName = Path.GetFileName(path);
+        string nameWithoutExtension = Path.GetFileNameWithoutExtension(path);
+        if (nameWithoutExtension.Any(char.IsWhiteSpace))
+            throw new InvalidDataException($"ISACT WAV names cannot contain spaces: {fileName}");
+        ulong lineId = 0;
+        DialogueGender gender = DialogueGender.Shared;
+        if (authoringMode == AuthoringMode.Conversation)
+        {
+            Match match = DialogueFileNameRegex().Match(nameWithoutExtension);
+            if (!match.Success || !ulong.TryParse(match.Groups["id"].Value, NumberStyles.None,
+                    CultureInfo.InvariantCulture, out lineId))
+            {
+                throw new InvalidDataException(
+                    $"Conversation WAV names must end in a numeric string reference, optionally followed by _F or _M: {fileName}");
+            }
+
+            gender = match.Groups["gender"].Value.ToUpperInvariant() switch
+            {
+                "F" => DialogueGender.Female,
+                "M" => DialogueGender.Male,
+                _ => DialogueGender.Shared
+            };
+        }
+
+        using var stream = File.OpenRead(path);
+        using var reader = new BinaryReader(stream, Encoding.ASCII, leaveOpen: true);
+        if (ReadFourCC(reader) != "RIFF")
+            throw new InvalidDataException($"WAV does not begin with RIFF: {fileName}");
+        _ = reader.ReadUInt32();
+        if (ReadFourCC(reader) != "WAVE")
+            throw new InvalidDataException($"RIFF file is not WAVE audio: {fileName}");
+
+        ushort format = 0;
+        ushort channels = 0;
+        int sampleRate = 0;
+        ushort blockAlign = 0;
+        ushort bitsPerSample = 0;
+        byte[] pcmData = null;
+        while (stream.Position + 8 <= stream.Length)
+        {
+            string chunkName = ReadFourCC(reader);
+            uint chunkSize = reader.ReadUInt32();
+            long chunkEnd = checked(stream.Position + chunkSize);
+            if (chunkEnd > stream.Length)
+                throw new InvalidDataException($"WAV contains a truncated {chunkName} chunk: {fileName}");
+
+            if (chunkName == "fmt ")
+            {
+                if (chunkSize < 16)
+                    throw new InvalidDataException($"WAV fmt chunk is too short: {fileName}");
+                format = reader.ReadUInt16();
+                channels = reader.ReadUInt16();
+                sampleRate = checked((int)reader.ReadUInt32());
+                _ = reader.ReadUInt32();
+                blockAlign = reader.ReadUInt16();
+                bitsPerSample = reader.ReadUInt16();
+            }
+            else if (chunkName == "data")
+            {
+                if (chunkSize > int.MaxValue)
+                    throw new InvalidDataException($"WAV data is too large: {fileName}");
+                pcmData = reader.ReadBytes((int)chunkSize);
+                if (pcmData.Length != chunkSize)
+                    throw new InvalidDataException($"WAV contains truncated PCM data: {fileName}");
+            }
+
+            long nextChunk = checked(chunkEnd + (chunkSize & 1));
+            if (nextChunk > stream.Length)
+                throw new InvalidDataException($"WAV contains truncated padding after {chunkName}: {fileName}");
+            stream.Position = nextChunk;
+        }
+
+        if (format != 1)
+            throw new InvalidDataException($"Only uncompressed PCM WAV files are supported: {fileName}");
+        if (bitsPerSample != 16)
+            throw new InvalidDataException($"ISACT authoring input must be signed 16-bit PCM: {fileName}");
+        if (channels is not (1 or 2))
+            throw new InvalidDataException($"ISACT dialogue input must be mono or stereo: {fileName}");
+        if (channels == 0 || sampleRate <= 0 || bitsPerSample == 0 || blockAlign == 0)
+            throw new InvalidDataException($"WAV has invalid format metadata: {fileName}");
+        if (pcmData is null)
+            throw new InvalidDataException($"WAV has no data chunk: {fileName}");
+        if (pcmData.Length % blockAlign != 0)
+            throw new InvalidDataException($"WAV data is not aligned to complete sample frames: {fileName}");
+        if (fileName.Length > 127)
+            throw new InvalidDataException($"ISACT sample names cannot exceed 127 characters: {fileName}");
+
+        return new WaveSample(path, fileName, lineId, gender, sampleRate, bitsPerSample, channels, blockAlign, pcmData);
+    }
+
+    private static void ValidateBankName(string bankName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bankName);
+        if (bankName != Path.GetFileName(bankName) || bankName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            throw new ArgumentException("Bank name must be a valid filename without a path.", nameof(bankName));
+        if (Path.HasExtension(bankName))
+            throw new ArgumentException("Bank name must not include a file extension.", nameof(bankName));
+    }
+
+    private static int GetChannelFlags(ushort channels) => channels switch
+    {
+        1 => 0x4, // Front centre
+        2 => 0x3, // Front left + front right
+        _ => 0
+    };
+
+    private static string ReadFourCC(BinaryReader reader) => Encoding.ASCII.GetString(reader.ReadBytes(4));
+
+    private static string ResolveBankBuilderExecutable(string path)
+    {
+        string executable = Directory.Exists(path) ? Path.Combine(path, "BankBuilder.exe") : path;
+        executable = Path.GetFullPath(executable);
+        if (!File.Exists(executable))
+            throw new FileNotFoundException("BankBuilder.exe was not found.", executable);
+        return executable;
+    }
+
+    private static string ResolveBankBuilderDependency(string bankBuilderExe, string dependencyName)
+    {
+        var searchDirectory = new DirectoryInfo(Path.GetDirectoryName(bankBuilderExe)!);
+        for (int level = 0; searchDirectory is not null && level < 8; level++, searchDirectory = searchDirectory.Parent)
+        {
+            string candidate = Path.Combine(searchDirectory.FullName, dependencyName);
+            if (File.Exists(candidate))
+                return candidate;
+        }
+        throw new FileNotFoundException(
+            $"{dependencyName} was not found beside BankBuilder.exe or in one of its parent directories.",
+            dependencyName);
+    }
+
+    private static bool ContainsBuilderFailure(string log)
+    {
+        foreach (string line in log.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!Regex.IsMatch(line, @"\b(warnings?|errors?)\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                continue;
+            if (Regex.IsMatch(line, @"\b(no|0)\s+(warnings?|errors?)\b|\b(warnings?|errors?)\s*:\s*0\b",
+                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                continue;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool HasBuilderCompletionSummary(string log) =>
+        Regex.IsMatch(log, @"(?m)^\s*\d+\s+Errors?\s+and\s+\d+\s+Warnings?\s*$",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static string TryReadBuilderLog(string path)
+    {
+        if (!File.Exists(path))
+            return string.Empty;
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream, detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+        catch (IOException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private static void ValidateBuiltBanks(
+        string icbPath, string isbPath, int expectedEventCount, bool expectedSoundQueue)
+    {
+        if (!File.Exists(icbPath))
+            throw new InvalidDataException($"BankBuilder did not produce the expected ICB: {icbPath}");
+        if (!File.Exists(isbPath))
+            throw new InvalidDataException($"BankBuilder did not produce the expected ISB: {isbPath}");
+
+        using var icbStream = File.OpenRead(icbPath);
+        var icb = new ISACTBank(icbStream);
+        if (icb.BankType != ISACTBankType.ICB)
+            throw new InvalidDataException("BankBuilder output ICB has the wrong bank type.");
+        int eventCount = icb.BankChunks.OfType<ISACTListBankChunk>().Count(list => list.ObjectType == "snde");
+        if (eventCount != expectedEventCount)
+            throw new InvalidDataException($"BankBuilder output contains {eventCount} events; expected {expectedEventCount}.");
+        int queueCount = icb.BankChunks.OfType<ISACTListBankChunk>().Count(list => list.ObjectType == "sdqu");
+        if (expectedSoundQueue && queueCount != 1)
+            throw new InvalidDataException($"BankBuilder output contains {queueCount} Sound Queues; expected one.");
+
+        ValidateFinalIsb(isbPath);
+    }
+
+    private static void ValidateFinalIsb(string isbPath)
+    {
+        using var isbStream = File.OpenRead(isbPath);
+        var isb = new ISACTBank(isbStream);
+        if (isb.BankType != ISACTBankType.ISB)
+            throw new InvalidDataException("BankBuilder output ISB has the wrong bank type.");
+        var sampleLists = isb.BankChunks.OfType<ISACTListBankChunk>().Where(list => list.ObjectType == "samp").ToList();
+        if (sampleLists.Count == 0)
+            throw new InvalidDataException("BankBuilder output ISB contains no samples.");
+        foreach (var sample in sampleLists)
+        {
+            if (sample.CompressionInfo.CurrentFormat != CompressionInfoBankChunk.ISACTCompressionFormat.OGGVORBIS)
+                throw new InvalidDataException($"BankBuilder did not encode sample {sample.TitleInfo?.Value} as Ogg Vorbis.");
+            if (sample.SampleData is not { Length: >= 4 } data || !data.AsSpan(0, 4).SequenceEqual("OggS"u8))
+                throw new InvalidDataException($"BankBuilder output sample {sample.TitleInfo?.Value} has invalid Ogg data.");
+        }
+    }
+
+    private static BankChunk IntChunk(string name, int value) => RawInt32Chunk(name, value);
+
+    private static BankChunk FloatChunk(string name, float value) =>
+        RawInt32Chunk(name, BitConverter.SingleToInt32Bits(value));
+
+    private static BankChunk RawInt32Chunk(string name, params int[] values)
+    {
+        byte[] data = new byte[values.Length * sizeof(int)];
+        for (int index = 0; index < values.Length; index++)
+            BinaryPrimitives.WriteInt32LittleEndian(data.AsSpan(index * sizeof(int)), values[index]);
+        return RawChunk(name, data);
+    }
+
+    private static BankChunk UnicodeChunk(string name, string value) =>
+        RawChunk(name, Encoding.Unicode.GetBytes(value + '\0'));
+
+    private static BankChunk RawChunk(string name, byte[] data) => new()
+    {
+        ChunkName = name,
+        RawData = data
+    };
+
+    [GeneratedRegex(@"(?<id>\d+)(?:_(?<gender>[FM]))?$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex DialogueFileNameRegex();
+
+    [GeneratedRegex(@"_(?:sb(?<racialVariant>\d)|(?<code>[A-Za-z]{3}))(?<index>\d{2})$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SoundsetFileNameRegex();
+}

--- a/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTHelper.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTHelper.cs
@@ -11,6 +11,8 @@ using System.Text;
 using LegendaryExplorerCore.Helpers;
 using LegendaryExplorerCore.Gammtek.Extensions.IO;
 using LegendaryExplorerCore.Gammtek.IO;
+using LegendaryExplorerCore.Unreal;
+using LegendaryExplorerCore.Unreal.BinaryConverters;
 
 namespace LegendaryExplorerCore.Sound.ISACT
 {
@@ -48,6 +50,70 @@ namespace LegendaryExplorerCore.Sound.ISACT
             wsdExport.WriteBinary(ms.ToArray());
 
             return null;
+        }
+
+        /// <summary>
+        /// Refreshes stripped ISB metadata while preserving the ICB.
+        /// </summary>
+        public static void RefreshStreamingDataSampleBank(ExportEntry wsdExport, string isbPath)
+        {
+            ArgumentNullException.ThrowIfNull(wsdExport);
+            if (wsdExport.ClassName != "BioSoundNodeWaveStreamingData")
+                throw new ArgumentException("The export must be BioSoundNodeWaveStreamingData.", nameof(wsdExport));
+            if (!File.Exists(isbPath))
+                throw new FileNotFoundException("ISB path not available.", isbPath);
+
+            ISACTBank externalIsb;
+            using (var stream = File.OpenRead(isbPath))
+                externalIsb = new ISACTBank(stream);
+            if (externalIsb.BankType != ISACTBankType.ISB)
+                throw new InvalidDataException("The selected file is not an ISACT sample bank.");
+            externalIsb.StripSamples();
+
+            var streamingData = wsdExport.GetBinaryData<BioSoundNodeWaveStreamingData>();
+            streamingData.BankPair.ISBBank = externalIsb;
+            wsdExport.WriteBinary(streamingData);
+        }
+
+        /// <summary>
+        /// Creates an LE1 streaming-data export for a compiled bank pair.
+        /// </summary>
+        public static ExportEntry CreateSoundNodeWaveStreamingData(
+            IMEPackage package, string bankName, string icbPath, string isbPath,
+            string localizationSuffix = "")
+        {
+            ArgumentNullException.ThrowIfNull(package);
+            ArgumentException.ThrowIfNullOrWhiteSpace(bankName);
+            if (package.Game != MEGame.LE1)
+                throw new ArgumentException("Streaming-data export creation is only supported for LE1 packages.", nameof(package));
+            localizationSuffix ??= "";
+            if (localizationSuffix.Length > 0 && !localizationSuffix.StartsWith('_'))
+                localizationSuffix = $"_{localizationSuffix}";
+            if (localizationSuffix is not ("" or "_DE" or "_FR" or "_IT" or "_PLPC" or "_RA"))
+                throw new ArgumentException($"Unsupported LE1 audio localization suffix: '{localizationSuffix}'.", nameof(localizationSuffix));
+
+            string localizedBankName = bankName + localizationSuffix;
+            ExportEntry streamingRoot = package.CreatePackageExport("DVDStreamingAudioData" + localizationSuffix);
+            ExportEntry pcPackage = package.CreatePackageExport("PC", streamingRoot);
+            if (package.FindExport($"{pcPackage.InstancedFullPath}.{localizedBankName}") is not null)
+                throw new InvalidOperationException(
+                    $"A streaming-data export named '{localizedBankName}' already exists. Select it for updating instead.");
+            ExportEntry streamingData = package.CreateExport(
+                new NameReference(localizedBankName), "BioSoundNodeWaveStreamingData", pcPackage, indexed: false);
+            GenerateSoundNodeWaveStreamingDataCS(streamingData, icbPath, isbPath);
+            return streamingData;
+        }
+
+        public static void ExportStreamingDataContentBank(ExportEntry wsdExport, string outputPath)
+        {
+            ArgumentNullException.ThrowIfNull(wsdExport);
+            ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+            if (wsdExport.ClassName != "BioSoundNodeWaveStreamingData")
+                throw new ArgumentException("The export must be BioSoundNodeWaveStreamingData.", nameof(wsdExport));
+
+            var streamingData = wsdExport.GetBinaryData<BioSoundNodeWaveStreamingData>();
+            using var stream = File.Create(outputPath);
+            streamingData.BankPair.ICBBank.Write(stream);
         }
 
         private static MemoryStream GetStreamingData(string icbPath, string isbPath)
@@ -135,6 +201,15 @@ namespace LegendaryExplorerCore.Sound.ISACT
         public ISACTBankType BankType;
         public long BankRIFFPosition { get; }
         public List<BankChunk> BankChunks { get; set; }
+
+        /// <summary>
+        /// Creates an empty bank.
+        /// </summary>
+        public ISACTBank(ISACTBankType bankType)
+        {
+            BankType = bankType;
+            BankChunks = new List<BankChunk>();
+        }
 
         public ISACTBank(Stream inStream)
         {
@@ -387,6 +462,12 @@ namespace LegendaryExplorerCore.Sound.ISACT
         /// </summary>
         public static readonly string FixedChunkTitle = "chnk";
         public int ChannelCount;
+
+        public ChannelBankChunk()
+        {
+            ChunkName = FixedChunkTitle;
+        }
+
         public ChannelBankChunk(Stream inStream, BankChunk parent)
         {
             Parent = parent;
@@ -516,6 +597,21 @@ namespace LegendaryExplorerCore.Sound.ISACT
             }
 
             // Map the items
+            foreach (var chunk in SubChunks)
+            {
+                BankSubChunkMap[chunk.ChunkName] = chunk;
+            }
+        }
+
+        /// <summary>
+        /// Creates a LIST object with the supplied child chunks.
+        /// </summary>
+        public ISACTListBankChunk(string objectType, IEnumerable<BankChunk> subChunks)
+        {
+            ChunkName = FixedChunkTitle;
+            ObjectType = objectType;
+            SubChunks = subChunks?.ToList() ?? new List<BankChunk>();
+
             foreach (var chunk in SubChunks)
             {
                 BankSubChunkMap[chunk.ChunkName] = chunk;
@@ -793,6 +889,11 @@ public class CompressionInfoBankChunk : BankChunk
     /// Not sure
     /// </summary>
     public float CompressionQuality;
+    public CompressionInfoBankChunk()
+    {
+        ChunkName = FixedChunkTitle;
+    }
+
     public CompressionInfoBankChunk(Stream inStream, BankChunk parent)
     {
         Parent = parent;
@@ -843,6 +944,11 @@ public class SampleInfoBankChunk : BankChunk
 
     //Content of Padding doesn't matter, but we save it so that we can do an identical reserialization (Its value is inconsistent)
     private ushort Padding;
+    public SampleInfoBankChunk()
+    {
+        ChunkName = FixedChunkTitle;
+    }
+
     public SampleInfoBankChunk(Stream inStream, BankChunk parent)
     {
         Parent = parent;

--- a/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTHelper.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Sound/ISACT/ISACTHelper.cs
@@ -78,19 +78,25 @@ namespace LegendaryExplorerCore.Sound.ISACT
         /// <summary>
         /// Creates an LE1 streaming-data export for a compiled bank pair.
         /// </summary>
+        /// <param name="package">Package that will contain the streaming-data export.</param>
+        /// <param name="bankName">Unlocalised bank name.</param>
+        /// <param name="icbPath">Compiled content-bank path.</param>
+        /// <param name="isbPath">Compiled sample-bank path.</param>
+        /// <param name="localization">Localisation used for LE1 object and sample-bank names.</param>
+        /// <returns>The newly created streaming-data export.</returns>
         public static ExportEntry CreateSoundNodeWaveStreamingData(
             IMEPackage package, string bankName, string icbPath, string isbPath,
-            string localizationSuffix = "")
+            MELocalization localization = MELocalization.None)
         {
             ArgumentNullException.ThrowIfNull(package);
             ArgumentException.ThrowIfNullOrWhiteSpace(bankName);
             if (package.Game != MEGame.LE1)
                 throw new ArgumentException("Streaming-data export creation is only supported for LE1 packages.", nameof(package));
-            localizationSuffix ??= "";
-            if (localizationSuffix.Length > 0 && !localizationSuffix.StartsWith('_'))
-                localizationSuffix = $"_{localizationSuffix}";
-            if (localizationSuffix is not ("" or "_DE" or "_FR" or "_IT" or "_PLPC" or "_RA"))
-                throw new ArgumentException($"Unsupported LE1 audio localization suffix: '{localizationSuffix}'.", nameof(localizationSuffix));
+
+            string locale = localization is MELocalization.None or MELocalization.INT
+                ? string.Empty
+                : localization.ToLocaleString(MEGame.LE1);
+            string localizationSuffix = locale.Length == 0 ? string.Empty : $"_{locale}";
 
             string localizedBankName = bankName + localizationSuffix;
             ExportEntry streamingRoot = package.CreatePackageExport("DVDStreamingAudioData" + localizationSuffix);
@@ -100,10 +106,16 @@ namespace LegendaryExplorerCore.Sound.ISACT
                     $"A streaming-data export named '{localizedBankName}' already exists. Select it for updating instead.");
             ExportEntry streamingData = package.CreateExport(
                 new NameReference(localizedBankName), "BioSoundNodeWaveStreamingData", pcPackage, indexed: false);
+            // Shipped INT and localized LE1 exports use Public and Standalone, not LocalizedResource.
+            // ExportEntry supplies the load flags and the forced package parent supplies ForcedExport.
+            streamingData.ObjectFlags |= UnrealFlags.EObjectFlags.Public | UnrealFlags.EObjectFlags.Standalone;
             GenerateSoundNodeWaveStreamingDataCS(streamingData, icbPath, isbPath);
             return streamingData;
         }
 
+        /// <summary>
+        /// Writes the embedded ICB from a streaming-data export.
+        /// </summary>
         public static void ExportStreamingDataContentBank(ExportEntry wsdExport, string outputPath)
         {
             ArgumentNullException.ThrowIfNull(wsdExport);


### PR DESCRIPTION
Add LE1 ISACT bank authoring and replacement tools to Soundplorer.

Features
- Build new ICB/ISB banks from WAV files.
- Rebuild existing banks by appending audio without recompressing existing audio.
- Support BioConversation, Codex, Soundset, and Music streaming workflow.
- Will automatically fix WAV files to signed 16-bit PCM if needed.
- Apply LE1 audio localisation suffixes.
- Create/update BioSoundNodeWaveStreamingData exports automatically.
- Optionally copy the completed ISB into a DLC mod Content folder.
- Replace individual audio files in an ISB and optionally refresh the matching package metadata.

Currently limitations are:
- BankBuilder.exe is still required as an external tool as it performs final compression
- Appending content to an existing looping music Sound Queue isn't currently supported.

Documentation is linked in the new windows, will be working on writing it while this PR is reviewed.